### PR TITLE
Add command completion function for bash

### DIFF
--- a/phalcon-completion.bash
+++ b/phalcon-completion.bash
@@ -1,0 +1,22 @@
+# Bash completion for phalcon-devtools, 
+# https://github.com/phalcon/phalcon-devtools
+
+_phalcon()
+{
+	local cur prev
+	_get_comp_words_by_ref -n = cur prev 
+
+	commands="commands list enumerate controller create-controller model \
+	create-model all-models create-all-models project create-project scaffold webtools"
+	
+	case "$prev" in
+		project|create-project)
+			COMPREPLY=($(compgen -W "--name --enable-webtools --directory --type --template-path --use-config-ini --trace --help" -- "$cur"))
+			return 0
+			;;
+	esac
+	
+	COMPREPLY=($(compgen -W "$commands" -- "$cur"))
+
+} &&
+complete -F _phalcon phalcon


### PR DESCRIPTION
Add command completion function for bash

```
$ source phalcon-completion.bash
$ phalcon <tab>
all-models         create-controller  list               webtools
commands           create-model       model
controller         create-project     project
create-all-models  enumerate          scaffold
```
