### PR TITLE
Fixed generated namespace in "modules" project template

### DIFF
--- a/templates/project/modules/Module.php
+++ b/templates/project/modules/Module.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Store\Frontend;
+namespace @@namespace@@\Frontend;
 
 class Module
 {


### PR DESCRIPTION
The generated namespace in Module.php was set to Store/Frontend regardless of the project name.
