### PR TITLE
Update phalcon.sh

### DIFF
--- a/ide/phpstorm/phalcon.sh
+++ b/ide/phpstorm/phalcon.sh
@@ -19,10 +19,10 @@
 #
 
 run_profile(){
-	if [ -e $HOME/.profile ]; then
-		. $HOME/.profile
-	elif [ -e $HOME/.bash_profile ]; then
+	if [ -e $HOME/.bash_profile ]; then
 		. $HOME/.bash_profile
+	elif [ -e $HOME/.profile ]; then
+		. $HOME/.profile
 	elif [ -e $HOME/.bashrc ]; then
 		. $HOME/.bashrc
 	elif [ -e $HOME/.zshrc]; then


### PR DESCRIPTION
On Ubuntu systems and probably any recent Debian based distribution, the .profile file is not read if a .bash_profile file exists.
So we need to check .bash_profile before .profile
