### PR TITLE
Update phalcon.sh

### DIFF
--- a/phalcon.sh
+++ b/phalcon.sh
@@ -25,14 +25,14 @@ alter_profile(){
 	export PATH="$PATH:$DIR"
 	PTOOLSVAR="export PTOOLSPATH=$DIR/"
 	PATHVAR="export PATH=\$PATH:$DIR"
-	if [ -e $HOME/.profile ]; then
-		echo "$PTOOLSVAR" >> $HOME/.profile
-		echo "$PATHVAR" >> $HOME/.profile
-		source $HOME/.profile
-	elif [ -e $HOME/.bash_profile ]; then
+	if [ -e $HOME/.bash_profile ]; then
 		echo "$PTOOLSVAR" >> $HOME/.bash_profile
 		echo "$PATHVAR" >> $HOME/.bash_profile
 		source $HOME/.bash_profile
+	elif [ -e $HOME/.profile ]; then
+		echo "$PTOOLSVAR" >> $HOME/.profile
+		echo "$PATHVAR" >> $HOME/.profile
+		source $HOME/.profile
 	elif [ -e $HOME/.bashrc ]; then
 				echo "$PTOOLSVAR" >> $HOME/.bashrc
 		echo "$PATHVAR" >> $HOME/.bashrc


### PR DESCRIPTION
On Ubuntu and probably any recent Debian-based distro, the .profile file is not read if a .bash_profile file exists.
So better write the PTOOLSPATH to .bash_profile first.
