### PR TITLE
Email and InclusionIn validations triggered parse error

### DIFF
--- a/scripts/Phalcon/Builder/Model.php
+++ b/scripts/Phalcon/Builder/Model.php
@@ -127,7 +127,7 @@ class Model extends Component
                     \"required\" => true,
                 )
             )
-        )";
+        );";
 
         $templateValidateEmail = "
         \$this->validate(
@@ -137,7 +137,7 @@ class Model extends Component
                     \"required\" => true,
                 )
             )
-        )";
+        );";
 
         $templateValidationFailed = "
         if (\$this->validationHasFailed() == true) {


### PR DESCRIPTION
Just a very small fix for the Email and InclusionIn validation templates. Just added a semicolon at the end of the object initialisation.

Sorry for the noise, but:
I did not wanted to change too much code, but have you considered adding the "\Phalcon\Mvc\Model\Validator\" namespace to the validation objects? Handy if you like your models namespaced.
