### PR TITLE
Small fix in scaffold template

### DIFF
--- a/templates/scaffold/no-forms/Controller.php
+++ b/templates/scaffold/no-forms/Controller.php
@@ -74,7 +74,7 @@ class $className$Controller extends ControllerBase
 
 		if (!$this->request->isPost()) {
 
-			$singularVar$ = $className$::findFirstById($id);
+			$singularVar$ = $className$::findFirstById($pkVar$);
 			if (!$singularVar$) {
 				$this->flash->error("$singular$ was not found");
 				return $this->dispatcher->forward(array(


### PR DESCRIPTION
on line 77 there was $id variable used, but if table primary key have another name, plural variable on like 72 will be same name, so $id variable case error.
