### PR TITLE
PHPDoc for models to specify that they return $this

### DIFF
--- a/scripts/Phalcon/Builder/Model.php
+++ b/scripts/Phalcon/Builder/Model.php
@@ -110,6 +110,7 @@ class Model extends Component
      * Method to set the value of field %s
      *
      * @param %s \$%s
+     * @return \$this
      */
     public function set%s(\$%s)
     {


### PR DESCRIPTION
Quite straight forward -- phpstorm was whining about this, so I figured I'd fix it in the template.
