### PR TITLE
Getting errrors on $db->getDatabaseName method does not exist

### DIFF
--- a/scripts/Phalcon/Builder/AllModels.php
+++ b/scripts/Phalcon/Builder/AllModels.php
@@ -96,11 +96,7 @@ class AllModels extends Component
         unset($configArray['adapter']);
         $db = new $adapterName($configArray);
 
-        $initialize = array();
         if (isset($this->_options['schema'])) {
-            if ($adapter !== 'Oracle' && $this->_options['schema'] != $db->getDatabaseName()) {
-                $initialize[] = "\t\t\$this->setSchema(\"{$this->_options['schema']}\");\n";
-            }
             $schema = $this->_options['schema'];
         } else if ($adapter == 'Postgresql') {
             $schema = 'public';


### PR DESCRIPTION
In my previous fix I thought maybe the Oracle adapter just didn't have this getDatabaseName method but I can't find it in any adapter. It also looks like this initialized method isn't used after this. So I thought this may be old code that could be removed.

If there is a reason for it let me know, I can add a getDatabaseName method to the Oracle adapter.
