### PR TITLE
Updating model builder to build proper syntax for foreign key

### DIFF
--- a/scripts/Phalcon/Builder/AllModels.php
+++ b/scripts/Phalcon/Builder/AllModels.php
@@ -138,23 +138,13 @@ class AllModels extends Component
                                 $belongsTo[$name][] = array(
                                     'referencedModel' => $referencedModel,
                                     'fields' => $columns[0],
-                                    'relationFields' => $referencedColumns[0]
+                                    'relationFields' => $referencedColumns[0],
+                                    'options' => $defineForeignKeys ? array('foreignKey'=>true) : NULL
                                 );
                                 $hasMany[$reference->getReferencedTable()][] = array(
                                     'camelizedName' => $camelizedName,
                                     'fields' => $referencedColumns[0],
                                     'relationFields' => $columns[0]
-                                );
-                            }
-                        }
-                    }
-                    if ($defineForeignKeys) {
-                        if ($reference->getReferencedSchema() == $refSchema) {
-                            if (count($columns) == 1) {
-                                $foreignKeys[$name][] = array(
-                                    'fields' => $columns[0],
-                                    'entity' => $referencedModel,
-                                    'referencedFields' => $referencedColumns[0]
                                 );
                             }
                         }

--- a/scripts/Phalcon/Builder/Model.php
+++ b/scripts/Phalcon/Builder/Model.php
@@ -103,7 +103,7 @@ class Model extends Component
     }
 ";
         $templateThis = "\t\t\$this->%s(%s);\n";
-        $templateRelation = "\t\t\$this->%s(\"%s\", \"%s\", \"%s\");\n";
+        $templateRelation = "\t\t\$this->%s(\"%s\", \"%s\", \"%s\", %s);\n";
         $templateSetter = "
     /**
      * Method to set the value of field %s
@@ -358,7 +358,8 @@ class %s extends %s
                             'hasMany',
                             $relation['fields'],
                             $entityName,
-                            $relation['relationFields']
+                            $relation['relationFields'],
+                            $this->_buildRelationOptions( isset($relation['options']) ? $relation["options"] : NULL)
                         );
                     }
                 }
@@ -375,24 +376,10 @@ class %s extends %s
                             'belongsTo',
                             $relation['fields'],
                             $entityName,
-                            $relation['relationFields']);
+                            $relation['relationFields'],
+                            $this->_buildRelationOptions(isset($relation['options']) ? $relation["options"] : NULL)
+                        );
                     }
-                }
-            }
-        }
-
-        if (isset($this->_options['foreignKeys'])) {
-            if (count($this->_options['foreignKeys']) &&
-                is_array($this->_options['foreignKeys'])
-            ) {
-                foreach ($this->_options['foreignKeys'] as $foreignKey) {
-                    $initialize[] = sprintf(
-                        $templateRelation,
-                        'addForeignKey',
-                        $foreignKey['fields'],
-                        $foreignKey['entity'],
-                        $foreignKey['referencedFields']
-                    );
                 }
             }
         }
@@ -607,6 +594,36 @@ class %s extends %s
                 'Model "' . $this->_options['name'] .
                 '" was successfully created.'
             ) . PHP_EOL;
+    }
+
+    /**
+     * Builds a PHP syntax with all the options in the array
+     * @param array $options
+     * @return string PHP syntax
+     */
+    private function _buildRelationOptions($options)
+    {
+        if (empty($options)) {
+            return 'NULL';
+        }
+
+        $values = array();
+        foreach ($options as $name=>$val)
+        {
+            if (is_bool($val)) {
+                $val = $val ? 'true':'false';
+            }
+            else if (!is_numeric($val)) {
+                $val = '"$val"';
+            }
+
+            $values[] = sprintf('"%s"=>%s', $name, $val);
+        }
+
+
+        $syntax = 'array('. implode(',', $values). ')';
+
+        return $syntax;
     }
 
     private function  _genColumnMapCode($fields)


### PR DESCRIPTION
As noted in those two issues:
https://github.com/phalcon/phalcon-devtools/issues/47
http://forum.phalconphp.com/discussion/436/generate-model-error-with-addforeignkey-method

model generator currently builds foreign key syntax like that:
$this->belongsTo("id", "Objects", "id");
$this->addForeignKey("id", "Objects", "id");

However, based on documentation of latest phalcon:
http://docs.phalconphp.com/en/latest/reference/models.html#virtual-foreign-keys

it should have been like that:
$this->belongsTo("owner_id", "Objects", "id", array(
            'foreignKey' => true
)); 

I updated the builder to support the new syntax. The update is done in a way that supports additional options in future.
