### PR TITLE
Scaffold issues when generating for tables with underscores.

### DIFF
--- a/scripts/Phalcon/Builder/Scaffold.php
+++ b/scripts/Phalcon/Builder/Scaffold.php
@@ -431,7 +431,7 @@ class Scaffold extends Component
 	private function _makeController($path, $options)
 	{
 
-		$controllerPath = $options['controllersDir'] . ucfirst(strtolower($options['className'])) . 'Controller.php';
+		$controllerPath = $options['controllersDir'] . $options['className'] . 'Controller.php';
 
 		if (file_exists($controllerPath)) {
 			return;
@@ -482,7 +482,7 @@ class Scaffold extends Component
 			mkdir($dirPathLayouts);
 		}
 
-		$fileName = Text::uncamelize($options['name']);
+		$fileName = $options['fileName'];
 		$viewPath = $dirPathLayouts . '/' . $fileName . '.phtml';
 		if (!file_exists($viewPath)) {
 
@@ -516,7 +516,7 @@ class Scaffold extends Component
 			mkdir($dirPathLayouts);
 		}
 
-		$fileName = Text::uncamelize($options['name']);
+		$fileName = Text::uncamelize($options['fileName']);
 		$viewPath = $dirPathLayouts . '/' . $fileName . '.volt';
 		if (!file_exists($viewPath)) {
 
@@ -542,7 +542,7 @@ class Scaffold extends Component
 	private function makeView($path, $options, $type)
 	{
 
-		$dirPath = $options['viewsDir'] . $options['name'];
+		$dirPath = $options['viewsDir'] . $options['fileName'];
 		if (is_dir($dirPath) == false) {
 			mkdir($dirPath);
 		}
@@ -573,7 +573,7 @@ class Scaffold extends Component
 	private function makeViewVolt($path, $options, $type)
 	{
 
-		$dirPath = $options['viewsDir'] . $options['name'];
+		$dirPath = $options['viewsDir'] . $options['fileName'];
 		if (is_dir($dirPath) == false) {
 			mkdir($dirPath);
 		}
@@ -658,7 +658,7 @@ class Scaffold extends Component
 	private function _makeViewSearch($path, $options)
 	{
 
-		$dirPath = $options['viewsDir'] . $options['name'];
+		$dirPath = $options['viewsDir'] . $options['fileName'];
 		if (is_dir($dirPath) == false) {
 			mkdir($dirPath);
 		}
@@ -710,7 +710,7 @@ class Scaffold extends Component
 	private function _makeViewSearchVolt($path, $options)
 	{
 
-		$dirPath = $options['viewsDir'] . $options['name'];
+		$dirPath = $options['viewsDir'] . $options['fileName'];
 		if (is_dir($dirPath) == false) {
 			mkdir($dirPath);
 		}

--- a/templates/scaffold/no-forms/Controller.php
+++ b/templates/scaffold/no-forms/Controller.php
@@ -25,7 +25,7 @@ class $className$Controller extends ControllerBase
 			$query = Criteria::fromInput($this->di, "$className$", $_POST);
 			$this->persistent->parameters = $query->getParams();
 		} else {
-			$numberPage = $this->request->getQuery("page", "int");			
+			$numberPage = $this->request->getQuery("page", "int");
 		}
 
 		$parameters = $this->persistent->parameters;
@@ -70,7 +70,7 @@ class $className$Controller extends ControllerBase
 
 		if (!$this->request->isPost()) {
 
-			$singularVar$ = $className$::findFirstById($pkVar$);
+			$singularVar$ = $className$::findFirstBy$pk$($pkVar$);
 			if (!$singularVar$) {
 				$this->flash->error("$singular$ was not found");
 				return $this->dispatcher->forward(array(


### PR DESCRIPTION
I tried to generate scaffold for a table named featured_product. And I get the following results:

```
/var/www/nowgocreate/app/config/../../app/controllers/FeaturedproductController.php
/var/www/nowgocreate/app/config/../../app/views/featuredproduct/index.volt
/var/www/nowgocreate/app/config/../../app/views/featuredproduct/search.volt
/var/www/nowgocreate/app/config/../../app/views/featuredproduct/new.volt
/var/www/nowgocreate/app/config/../../app/views/featuredproduct/edit.volt
```

This loads the index page correctly, but nothing else works. The pages all try to link to featured_product pages. To The new code now generates a FeaturedProductController and puts all views and layout in a featured_product directory instead:

```
/var/www/nowgocreate/app/config/../../app/controllers/FeaturedProductController.php
/var/www/nowgocreate/app/config/../../app/views/featured_product/index.volt
/var/www/nowgocreate/app/config/../../app/views/featured_product/search.volt
/var/www/nowgocreate/app/config/../../app/views/featured_product/new.volt
/var/www/nowgocreate/app/config/../../app/views/featured_product/edit.volt
```

This happened in both volt and php template generation. I've resolved it for both.
