### PR TITLE
Correct method definition for ModuleDefinitionInterface::registerAutoloaders

### DIFF
--- a/ide/0.8.0/Phalcon/Mvc/ModuleDefinitionInterface.php
+++ b/ide/0.8.0/Phalcon/Mvc/ModuleDefinitionInterface.php
@@ -11,8 +11,9 @@ namespace Phalcon\Mvc {
 		/**
 		 * Registers an autoloader related to the module
 		 *
+		 * @param \Phalcon\DiInterface $dependencyInjector
 		 */
-		public function registerAutoloaders();
+		public function registerAutoloaders($dependencyInjector);
 
 
 		/**

--- a/ide/0.9.0/Phalcon/Mvc/ModuleDefinitionInterface.php
+++ b/ide/0.9.0/Phalcon/Mvc/ModuleDefinitionInterface.php
@@ -11,8 +11,9 @@ namespace Phalcon\Mvc {
 		/**
 		 * Registers an autoloader related to the module
 		 *
+		 * @param \Phalcon\DiInterface $dependencyInjector
 		 */
-		public function registerAutoloaders();
+		public function registerAutoloaders($dependencyInjector);
 
 
 		/**

--- a/ide/1.0.0/Phalcon/Mvc/ModuleDefinitionInterface.php
+++ b/ide/1.0.0/Phalcon/Mvc/ModuleDefinitionInterface.php
@@ -11,8 +11,9 @@ namespace Phalcon\Mvc {
 		/**
 		 * Registers an autoloader related to the module
 		 *
+		 * @param \Phalcon\DiInterface $dependencyInjector
 		 */
-		public function registerAutoloaders();
+		public function registerAutoloaders($dependencyInjector);
 
 
 		/**

--- a/ide/1.1.0/Phalcon/Mvc/ModuleDefinitionInterface.php
+++ b/ide/1.1.0/Phalcon/Mvc/ModuleDefinitionInterface.php
@@ -11,8 +11,9 @@ namespace Phalcon\Mvc {
 		/**
 		 * Registers an autoloader related to the module
 		 *
+		 * @param \Phalcon\DiInterface $dependencyInjector
 		 */
-		public function registerAutoloaders();
+		public function registerAutoloaders($dependencyInjector);
 
 
 		/**

--- a/ide/1.2.0/Phalcon/Mvc/ModuleDefinitionInterface.php
+++ b/ide/1.2.0/Phalcon/Mvc/ModuleDefinitionInterface.php
@@ -11,8 +11,9 @@ namespace Phalcon\Mvc {
 		/**
 		 * Registers an autoloader related to the module
 		 *
+		 * @param \Phalcon\DiInterface $dependencyInjector
 		 */
-		public function registerAutoloaders();
+		public function registerAutoloaders($dependencyInjector);
 
 
 		/**

--- a/ide/1.2.3/Phalcon/Mvc/ModuleDefinitionInterface.php
+++ b/ide/1.2.3/Phalcon/Mvc/ModuleDefinitionInterface.php
@@ -11,8 +11,9 @@ namespace Phalcon\Mvc {
 		/**
 		 * Registers an autoloader related to the module
 		 *
+		 * @param \Phalcon\DiInterface $dependencyInjector
 		 */
-		public function registerAutoloaders();
+		public function registerAutoloaders($dependencyInjector);
 
 
 		/**

--- a/ide/1.2.4/Phalcon/Mvc/ModuleDefinitionInterface.php
+++ b/ide/1.2.4/Phalcon/Mvc/ModuleDefinitionInterface.php
@@ -11,8 +11,9 @@ namespace Phalcon\Mvc {
 		/**
 		 * Registers an autoloader related to the module
 		 *
+		 * @param \Phalcon\DiInterface $dependencyInjector
 		 */
-		public function registerAutoloaders();
+		public function registerAutoloaders($dependencyInjector);
 
 
 		/**


### PR DESCRIPTION
Signature of method Phalcon\Mvc\ModuleDefinitionInterface::registerAutoloaders() was changed in v0.8.0 but ide files were not updated.
