### PR TITLE
tableName option sent to the 'run' action in the Migration command

### DIFF
--- a/scripts/Phalcon/Commands/Builtin/Migration.php
+++ b/scripts/Phalcon/Commands/Builtin/Migration.php
@@ -161,6 +161,7 @@ class Migration extends Command implements CommandsInterface
             if ($action == 'run') {
                 Migrations::run(array(
                     'directory' => $path,
+                    'tableName' => $tableName,
                     'migrationsDir' => $migrationsDir,
                     'force' => $this->isReceivedOption('force'),
                     'config' => $config


### PR DESCRIPTION
The 'tableName' option is now being sent to the run method inside the Migration command, this way you can run migrations for only one table at a time.
