### PR TITLE
Fixing issue #94 (migration of unsigned columns)

### DIFF
--- a/scripts/Phalcon/Mvc/Model/Migration.php
+++ b/scripts/Phalcon/Mvc/Model/Migration.php
@@ -196,6 +196,10 @@ class Migration
             //	$fieldDefinition[] = "'primary' => true";
             //}
 
+            if ($field->isUnsigned()) {
+                $fieldDefinition[] = "'unsigned' => true";
+            }
+
             if ($field->isNotNull()) {
                 $fieldDefinition[] = "'notNull' => true";
             }


### PR DESCRIPTION
Trivial change. The functionality for checking unsigned int columns is on board, but was not used on migration::generate.
