### PR TITLE
trim on version string

### DIFF
--- a/scripts/Phalcon/Version/Item.php
+++ b/scripts/Phalcon/Version/Item.php
@@ -56,6 +56,7 @@ class Item
     {
         $n = 9;
         $versionStamp = 0;
+        $version = trim($version);
         $this->_parts = explode('.', $version);
         $nParts = count($this->_parts);
         if ($nParts < $numberParts) {


### PR DESCRIPTION
If you manualy change .phalcon/migration-version, migration run will only trigger last version beside number version placed in .phalcon/migration-version.

This fix resolve this issue by trimming all white spaces that can be left by manualy editing migration-version file
