### PR TITLE
Added namespace support to scaffolding

### DIFF
--- a/scripts/Phalcon/Builder/Scaffold.php
+++ b/scripts/Phalcon/Builder/Scaffold.php
@@ -169,8 +169,15 @@ class Scaffold extends Component
         $options['className'] = Text::camelize($options['name']);
         $options['fileName'] = Text::uncamelize($options['className']);
 
-        $modelClass = Text::camelize($name);
-        $modelPath = $config->application->modelsDir.'/'.$modelClass.'.php';
+
+        $modelsNamespace = $options['modelsNamespace'];
+        if (isset($modelsNamespace) && substr($modelsNamespace, -1) !== '\\') {
+            $modelsNamespace .= "\\";
+        }
+
+        $modelName = Text::camelize($name);
+        $modelClass = $modelsNamespace . $modelName;
+        $modelPath = $config->application->modelsDir.'/'.$modelName.'.php';
         if (!file_exists($modelPath)) {
 
             $modelBuilder = new ModelBuilder(array(
@@ -532,6 +539,12 @@ class Scaffold extends Component
         $path = $options['templatePath'] . '/scaffold/no-forms/Controller.php';
 
         $code = file_get_contents($path);
+
+        if (isset($options['controllersNamespace']) === true) {
+            $code = str_replace('$namespace$', 'namespace '.$options['controllersNamespace'].';'.PHP_EOL, $code);
+        } else {
+            $code = str_replace('$namespace$', ' ', $code);
+        }
 
         $code = str_replace('$singularVar$', '$' . $options['singular'], $code);
         $code = str_replace('$singular$', $options['singular'], $code);

--- a/scripts/Phalcon/Commands/Builtin/Scaffold.php
+++ b/scripts/Phalcon/Commands/Builtin/Scaffold.php
@@ -49,6 +49,8 @@ class Scaffold extends Command implements CommandsInterface
         'template-engine=s'=> 'Define the template engine, default php (php, volt). [optional]',
         'force'          => "Forces to rewrite generated code if they already exists. [optional]",
         'trace'          => "Shows the trace of the framework in case of exception. [optional]",
+        'ns-models=s'     => "Model's namespace [optional]",
+        'ns-controllers=s'     => "Controller's namespace [optional]",
     );
 
     /**
@@ -72,6 +74,8 @@ class Scaffold extends Command implements CommandsInterface
             'directory' => $this->getOption('directory'),
             'templatePath' => $templatePath,
             'templateEngine'=> $templateEngine,
+            'modelsNamespace' => $this->getOption('ns-models'),
+            'controllersNamespace' => $this->getOption('ns-controllers'),
         ));
 
         return $scaffoldBuilder->build();

--- a/templates/scaffold/no-forms/Controller.php
+++ b/templates/scaffold/no-forms/Controller.php
@@ -1,5 +1,5 @@
 <?php
-
+$namespace$
 use Phalcon\Mvc\Model\Criteria;
 use Phalcon\Paginator\Adapter\Model as Paginator;
 


### PR DESCRIPTION
It is now possible to specify the Model’s and Controller’s namespace
when scaffolding.
Options added:
—ns-models=s         Model's namespace [optional]
—ns-controllers=s    Controller's namespace [optional]
