### PR TITLE
Change composer dependency to "require-dev"

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Create the composer.json file as follows:
 
 ```json
 {
-    "require": {
+    "require-dev": {
         "phalcon/devtools": "dev-master"
     }
 }


### PR DESCRIPTION
As this tool is only used to dev purposes, I think the composer dependency must be set only for dev env.