### PR TITLE
Phalcon/Image/Adapter PHPStorm errors: function must have body or be abstract

### DIFF
--- a/ide/1.3.1/Phalcon/Image/Adapter.php
+++ b/ide/1.3.1/Phalcon/Image/Adapter.php
@@ -239,49 +239,49 @@ namespace Phalcon\Image {
 		public function render($type=null, $quality=null){ }
 
 
-		abstract protected function _resize($width, $height){ }
+		abstract protected function _resize($width, $height);
 
 
-		abstract protected function _liquidRescale($width, $height, $delta_x, $regidity){ }
+		abstract protected function _liquidRescale($width, $height, $delta_x, $regidity);
 
 
-		abstract protected function _crop($width, $height, $offset_x, $offset_y){ }
+		abstract protected function _crop($width, $height, $offset_x, $offset_y);
 
 
-		abstract protected function _rotate($degrees){ }
+		abstract protected function _rotate($degrees);
 
 
-		abstract protected function _flip($direction){ }
+		abstract protected function _flip($direction);
 
 
-		abstract protected function _sharpen($amount){ }
+		abstract protected function _sharpen($amount);
 
 
-		abstract protected function _reflection($height, $opacity, $fade_in){ }
+		abstract protected function _reflection($height, $opacity, $fade_in);
 
 
-		abstract protected function _watermark($watermark, $offset_x, $offset_y, $opacity){ }
+		abstract protected function _watermark($watermark, $offset_x, $offset_y, $opacity);
 
 
-		abstract protected function _text($text, $offset_x, $offset_y, $opacity, $r, $g, $b, $size, $fontfile){ }
+		abstract protected function _text($text, $offset_x, $offset_y, $opacity, $r, $g, $b, $size, $fontfile);
 
 
-		abstract protected function _mask($mask){ }
+		abstract protected function _mask($mask);
 
 
-		abstract protected function _background($r, $g, $b, $opacity){ }
+		abstract protected function _background($r, $g, $b, $opacity);
 
 
-		abstract protected function _blur($radius){ }
+		abstract protected function _blur($radius);
 
 
-		abstract protected function _pixelate($amount){ }
+		abstract protected function _pixelate($amount);
 
 
-		abstract protected function _save($file, $quality){ }
+		abstract protected function _save($file, $quality);
 
 
-		abstract protected function _render($type, $quality){ }
+		abstract protected function _render($type, $quality);
 
 	}
 }


### PR DESCRIPTION
PHPStorm was showing errors at Phalcon/Image/Adapter: function must have body or be abstract. I've modified stubs to be without errors. All other files seems to work just fine.
