### PR TITLE
Last migration always tries to execute

### DIFF
--- a/scripts/Phalcon/Version/Item.php
+++ b/scripts/Phalcon/Version/Item.php
@@ -158,7 +158,7 @@ class Item
             /**
              * @var $version Item
              */
-            if (($version->getStamp() >= $initialVersion->getStamp()) && ($version->getStamp() <= $finalVersion->getStamp())) {
+            if (($version->getStamp() > $initialVersion->getStamp()) && ($version->getStamp() <= $finalVersion->getStamp())) {
                 $betweenVersions[] = $version;
             }
         }


### PR DESCRIPTION
Without this fix last migration always tries to execute regardless of the current version in phalcon-migration file
