### PR TITLE
Migrations: Added missing namespace, made config regexp case insensitive 

### DIFF
--- a/scripts/Phalcon/Commands/Builtin/Migration.php
+++ b/scripts/Phalcon/Commands/Builtin/Migration.php
@@ -21,6 +21,7 @@
 namespace Phalcon\Commands\Builtin;
 
 use Phalcon\Builder;
+use Phalcon\Builder\BuilderException;
 use Phalcon\Script\Color;
 use Phalcon\Commands\Command;
 use Phalcon\Commands\CommandsInterface;
@@ -99,7 +100,7 @@ class Migration extends Command implements CommandsInterface
         $directory = new \RecursiveDirectoryIterator('.');
         $iterator = new \RecursiveIteratorIterator($directory);
         foreach ($iterator as $f) {
-            if (preg_match('/config\.php$/', $f->getPathName())) {
+            if (preg_match('/config\.php$/i', $f->getPathName())) {
                 $config = include($f->getPathName());
 
                 return $config;


### PR DESCRIPTION
Migrations: Added missing namespace, made config regexp case insensitive 
