### PR TITLE
Fixed: table row tags in views are now correctly closed.

### DIFF
--- a/templates/scaffold/no-forms/views/edit.phtml
+++ b/templates/scaffold/no-forms/views/edit.phtml
@@ -7,7 +7,7 @@
     <tr>
         <td align="left"><?php echo $this->tag->linkTo(array("$plural$", "Back")) ?></td>
         <td align="right"><?php echo $this->tag->submitButton("Save") ?></td>
-    <tr>
+    </tr>
 </table>
 
 <div align="center">

--- a/templates/scaffold/no-forms/views/edit.volt
+++ b/templates/scaffold/no-forms/views/edit.volt
@@ -5,7 +5,7 @@
     <tr>
         <td align="left">{{ link_to("$plural$", "Go Back") }}</td>
         <td align="right">{{ submit_button("Save") }}</td>
-    <tr>
+    </tr>
 </table>
 
 <div align="center">

--- a/templates/scaffold/no-forms/views/new.phtml
+++ b/templates/scaffold/no-forms/views/new.phtml
@@ -5,7 +5,7 @@
     <tr>
         <td align="left"><?php echo $this->tag->linkTo(array("$plural$", "Go Back")) ?></td>
         <td align="right"><?php echo $this->tag->submitButton("Save") ?></td>
-    <tr>
+    </tr>
 </table>
 
 <?php echo $this->getContent(); ?>

--- a/templates/scaffold/no-forms/views/new.volt
+++ b/templates/scaffold/no-forms/views/new.volt
@@ -5,7 +5,7 @@
     <tr>
         <td align="left">{{ link_to("$plural$", "Go Back") }}</td>
         <td align="right">{{ submit_button("Save") }}</td>
-    <tr>
+    </tr>
 </table>
 
 {{ content() }}

--- a/templates/scaffold/no-forms/views/search.phtml
+++ b/templates/scaffold/no-forms/views/search.phtml
@@ -10,7 +10,7 @@
         <td align="right">
             <?php echo $this->tag->linkTo(array("$plural$/new", "Create ")); ?>
         </td>
-    <tr>
+    </tr>
 </table>
 
 <table class="browse" align="center">

--- a/templates/scaffold/no-forms/views/search.volt
+++ b/templates/scaffold/no-forms/views/search.volt
@@ -9,7 +9,7 @@
         <td align="right">
             {{ link_to("$plural$/new", "Create ") }}
         </td>
-    <tr>
+    </tr>
 </table>
 
 <table class="browse" align="center">


### PR DESCRIPTION
The scaffolding templates were missing a "/" in a few of the tags.
