### PR TITLE
One can now choose to ignore the schema name for migrations 

### DIFF
--- a/scripts/Phalcon/Commands/Builtin/Migration.php
+++ b/scripts/Phalcon/Commands/Builtin/Migration.php
@@ -48,6 +48,7 @@ class Migration extends Command implements CommandsInterface
         'table=s' 		=> "Table to migrate. Default: all.",
         'version=s' 	=> "Version to migrate.",
         'force' 		=> "Forces to overwrite existing migrations.",
+        'ignoreSchema' => "Does not save the schema name in migration files",
     );
 
     /**
@@ -155,6 +156,7 @@ class Migration extends Command implements CommandsInterface
                 'migrationsDir' => $migrationsDir,
                 'originalVersion' => $originalVersion,
                 'force' => $this->isReceivedOption('force'),
+                'ignoreSchema' => $this->isReceivedOption('ignoreSchema'),
                 'config' => $config
             ));
         } else {

--- a/scripts/Phalcon/Migrations.php
+++ b/scripts/Phalcon/Migrations.php
@@ -42,6 +42,7 @@ class Migrations
         $exportData = $options['exportData'];
         $migrationsDir = $options['migrationsDir'];
         $originalVersion = $options['originalVersion'];
+        $ignoreSchema = $options['ignoreSchema'];
         $force = $options['force'];
         $config = $options['config'];
 
@@ -94,12 +95,12 @@ class Migrations
 
         ModelMigration::setMigrationPath($migrationsDir.'/'.$version);
         if ($tableName == 'all') {
-            $migrations = ModelMigration::generateAll($version, $exportData);
+            $migrations = ModelMigration::generateAll($version, $exportData, $ignoreSchema);
             foreach ($migrations as $tableName => $migration) {
                 file_put_contents($migrationsDir.'/'.$version.'/'.$tableName.'.php', '<?php '.PHP_EOL.PHP_EOL.$migration);
             }
         } else {
-            $migration = ModelMigration::generate($version, $tableName, $exportData);
+            $migration = ModelMigration::generate($version, $tableName, $exportData, $ignoreSchema);
             file_put_contents($migrationsDir.'/'.$version.'/'.$tableName.'.php', '<?php '.PHP_EOL.PHP_EOL.$migration);
         }
 


### PR DESCRIPTION
Added option 'ignoreSchema' to generate migration files that won't specify the database name in foreign key definitions because databases don't necessarily have the same name on development, test, stage or production servers.

When running a migration with those files it automatically uses the db name from the phalcon config.
