### PR TITLE
Change require to require_once in Model Migration

### DIFF
--- a/scripts/Phalcon/Mvc/Model/Migration.php
+++ b/scripts/Phalcon/Mvc/Model/Migration.php
@@ -349,7 +349,7 @@ class ".$className." extends Migration\n".
             $fileName = basename($filePath);
             $classVersion = preg_replace('/[^0-9A-Za-z]/', '', $version);
             $className = \Phalcon\Text::camelize(str_replace('.php', '', $fileName)).'Migration_'.$classVersion;
-            require $filePath;
+            require_once $filePath;
             if (class_exists($className)) {
                 $migration = new $className();
                 if (method_exists($migration, 'up')) {


### PR DESCRIPTION
Allows for sequential running of Migrations on several Databases using something like a Task. See ticket #225 for more details.
