### PR TITLE
added support for the --version tag

### DIFF
--- a/scripts/Phalcon/Commands/Builtin/Migration.php
+++ b/scripts/Phalcon/Commands/Builtin/Migration.php
@@ -148,6 +148,11 @@ class Migration extends Command implements CommandsInterface
 
         $action = $this->getOption(array('action', 1));
 
+        $version = $this->getOption('version');
+        
+        
+
+
         if ($action == 'generate') {
             Migrations::generate(array(
                 'directory' => $path,
@@ -165,7 +170,8 @@ class Migration extends Command implements CommandsInterface
                     'tableName' => $tableName,
                     'migrationsDir' => $migrationsDir,
                     'force' => $this->isReceivedOption('force'),
-                    'config' => $config
+                    'config' => $config ,
+                    'version' => $version ,
                 ));
             }
         }

--- a/scripts/Phalcon/Migrations.php
+++ b/scripts/Phalcon/Migrations.php
@@ -24,6 +24,8 @@ use Phalcon\Script\Color;
 use Phalcon\Version\Item as VersionItem;
 use Phalcon\Mvc\Model\Migration as ModelMigration;
 
+
+
 class Migrations
 {
 
@@ -128,6 +130,14 @@ class Migrations
         $path = $options['directory'];
         $migrationsDir = $options['migrationsDir'];
         $config = $options['config'];
+        $version = null ;
+
+
+
+        if ( isset($options['version']) && $options['version'] !== null){
+            $version = new VersionItem($options['version']);
+        } 
+
 
         if (isset($options['tableName'])) {
             $tableName = $options['tableName'];
@@ -149,11 +159,16 @@ class Migrations
             }
         }
 
-        if (count($versions) == 0) {
+
+        if ( count($versions) == 0) {
             throw new \Phalcon\Mvc\Model\Exception('Migrations were not found at '.$migrationsDir);
         } else {
-            $version = VersionItem::maximum($versions);
+
+            if ($version === null){
+                $version = VersionItem::maximum($versions);
+            }
         }
+
 
         if (is_file($path.'.phalcon')) {
             unlink($path.'.phalcon');
@@ -173,13 +188,16 @@ class Migrations
             throw new \Exception("Cannot load database configuration");
         }
 
-        ModelMigration::setMigrationPath($migrationsDir.'/'.$version);
+        ModelMigration::setMigrationPath($migrationsDir.'/'.$version . '/') ;
         $versionsBetween = VersionItem::between($fromVersion, $version, $versions);
+
         foreach ($versionsBetween as $version) {
             if ($tableName == 'all') {
-                $iterator = new \DirectoryIterator($migrationsDir.'/'.$version);
+                 $iterator = new \DirectoryIterator($migrationsDir.'/'.$version);
                 foreach ($iterator as $fileinfo) {
                     if ($fileinfo->isFile()) {
+                 
+
                         if (preg_match('/\.php$/', $fileinfo->getFilename())) {
                             \Phalcon\Mvc\Model\Migration::migrateFile((string) $version, $migrationsDir.'/'.$version.'/'.$fileinfo->getFilename());
                         }
@@ -198,5 +216,7 @@ class Migrations
 
         file_put_contents($migrationFid, (string) $version);
     }
+
+
 
 }

--- a/scripts/Phalcon/Version/Item.php
+++ b/scripts/Phalcon/Version/Item.php
@@ -144,6 +144,8 @@ class Item
      */
     public static function between($initialVersion, $finalVersion, $versions)
     {
+        $versions = self::sortAsc($versions);
+
         if (!is_object($initialVersion)) {
             $initialVersion = new self($initialVersion);
         }
@@ -151,6 +153,7 @@ class Item
             $finalVersion = new self($finalVersion);
         }
         if ($initialVersion->getStamp() > $finalVersion->getStamp()) {
+            $versions = self::sortDesc($versions);
             list($initialVersion, $finalVersion) = array($finalVersion, $initialVersion);
         }
         $betweenVersions = array();
@@ -158,12 +161,11 @@ class Item
             /**
              * @var $version Item
              */
-            if (($version->getStamp() > $initialVersion->getStamp()) && ($version->getStamp() <= $finalVersion->getStamp())) {
+            if (($version->getStamp() >= $initialVersion->getStamp()) && ($version->getStamp() <= $finalVersion->getStamp())) {
                 $betweenVersions[] = $version;
             }
         }
-
-        return self::sortAsc($betweenVersions);
+        return $betweenVersions ;
     }
 
     /**


### PR DESCRIPTION
phalcon migration run --version  option was not working. I didn't see where it was using the argument any where. 

I made some changes so that it will run the migrations from the migration-version ( from .phalcon/migration-version ) to the version given. 
