### PR TITLE
Fix: Correctly closes template <tbody> tags on search pagination controls.

### DIFF
--- a/templates/scaffold/no-forms/views/search.phtml
+++ b/templates/scaffold/no-forms/views/search.phtml
@@ -40,5 +40,5 @@ $rowColumns$            <td><?php echo $this->tag->linkTo(array("$plural$/edit/"
                 </table>
             </td>
         </tr>
-    <tbody>
+    </tbody>
 </table>

--- a/templates/scaffold/no-forms/views/search.volt
+++ b/templates/scaffold/no-forms/views/search.volt
@@ -41,5 +41,5 @@ $rowColumns$            <td>{{ link_to("$plural$/edit/"~$singularVar$.$pk$, "Edi
                 </table>
             </td>
         </tr>
-    <tbody>
+    </tbody>
 </table>


### PR DESCRIPTION
Small fix to the <tbody> tags in the pagination on search that weren't correctly closed.
