### PR TITLE
Fixed issue with getSource() when forcing model generation

### DIFF
--- a/scripts/Phalcon/Builder/Model.php
+++ b/scripts/Phalcon/Builder/Model.php
@@ -418,7 +418,9 @@ class Model extends Component
                         $possibleMethods['get' . $methodName] = true;
                     }
                 }
+                
                 $possibleMethods['getSource'] = true;
+                $possibleMethods['initialize'] = true;
 
                 require $modelPath;
 

--- a/scripts/Phalcon/Builder/Model.php
+++ b/scripts/Phalcon/Builder/Model.php
@@ -230,7 +230,7 @@ class Model extends Component
 }
 ";
 
-        $propertyLineTemplate = "* @property \%s %s";
+        $propertyLineTemplate = "* @property %s %s";
         $propertiesTemplate = "/**
  * Class %s
  %s
@@ -394,7 +394,7 @@ class Model extends Component
                             $this->_buildRelationOptions( isset($relation['options']) ? $relation["options"] : NULL)
                         );
 
-                        $propertyLines[] = sprintf($propertyLineTemplate, $entityNamespace . $entityName, $entityName);
+                        $propertyLines[] = sprintf($propertyLineTemplate, '\\Phalcon\\Mvc\\Model\\Resultset\\Simple', $entityName);
                     }
                 }
             }
@@ -423,7 +423,7 @@ class Model extends Component
                             $this->_buildRelationOptions(isset($relation['options']) ? $relation["options"] : NULL)
                         );
 
-                        $propertyLines[] = sprintf($propertyLineTemplate, $entityNamespace . $entityName, $entityName);
+                        $propertyLines[] = sprintf($propertyLineTemplate,  $entityName, $entityName);
                     }
                 }
             }

--- a/scripts/Phalcon/Builder/Model.php
+++ b/scripts/Phalcon/Builder/Model.php
@@ -418,6 +418,7 @@ class Model extends Component
                         $possibleMethods['get' . $methodName] = true;
                     }
                 }
+                $possibleMethods['getSource'] = true;
 
                 require $modelPath;
 


### PR DESCRIPTION
The dev tools somehow added a second getSource() when generating models if run with the --force parameter. This is no longer the case.