### PR TITLE
Fix duplicate migration if initalVersion == finalVersion

### DIFF
--- a/scripts/Phalcon/Version/Item.php
+++ b/scripts/Phalcon/Version/Item.php
@@ -157,6 +157,8 @@ class Item
             list($initialVersion, $finalVersion) = array($finalVersion, $initialVersion);
         }
         $betweenVersions = array();
+        if ($initialVersion->getStamp() == $finalVersion->getStamp()) return $betweenVersions;
+
         foreach ($versions as $version) {
             /**
              * @var $version Item


### PR DESCRIPTION
When the fromVersion equals to finalVersion (eg: 1.0.0 == 1.0.0), the migration run for 1.0.0 every time `phalcon migration run` invoked