### PR TITLE
Corretion to work micro-based app templates

### DIFF
--- a/templates/project/micro/config.ini
+++ b/templates/project/micro/config.ini
@@ -6,6 +6,6 @@ password = secret
 dbname     = test
 
 [application]
-modelsDir      = /models/
-modelsDir      = /views/
+modelsDir      = ../models/
+viewsDir      = ../views/
 baseUri        = /@@name@@/


### PR DESCRIPTION
This fix aims to start a new project based on Micro that works without any errors: 
Ex: PHALCON project --name website --type = simple --use-config-ini---enable webtools
