### PR TITLE
Removed APP_PATH, switched back to use __DIR__

### DIFF
--- a/templates/project/micro/config.php
+++ b/templates/project/micro/config.php
@@ -11,8 +11,8 @@ return new \Phalcon\Config(array(
     ),
 
     'application' => array(
-        'modelsDir'      => APP_PATH . '/models/',
-        'viewsDir'       => APP_PATH . '/views/',
+        'modelsDir'      => __DIR__ . '/../models/',
+        'viewsDir'       => __DIR__ . '/../views/',
         'baseUri'        => '/@@name@@/',
     )
 ));

--- a/templates/project/micro/index.php
+++ b/templates/project/micro/index.php
@@ -4,8 +4,6 @@ use Phalcon\Mvc\Micro;
 
 error_reporting(E_ALL);
 
-define('APP_PATH', realpath('..'));
-
 try {
 
     /**
@@ -16,12 +14,12 @@ try {
     /**
      * Include Services
      */
-    include APP_PATH . '/config/services.php';
+    include __DIR__ . '/../config/services.php';
 
     /**
      * Include Autoloader
      */
-    include APP_PATH . '/config/loader.php';
+    include __DIR__ . '/../config/loader.php';
 
     /**
      * Starting the application
@@ -32,7 +30,7 @@ try {
     /**
      * Incude Application
      */
-    include APP_PATH . '/app.php';
+    include __DIR__ . '/../app.php';
 
     /**
      * Handle the request


### PR DESCRIPTION
Using a constant APP_PATH was causing error for "phalcon model [name]" command. I switched the template back to use magic one __ DIR __ fixing the problem.

![image](https://cloud.githubusercontent.com/assets/4115643/4710632/8b98cdfa-58ac-11e4-9f82-5738f976fe6c.png)
