### PR TITLE
add  path to app director

### DIFF
--- a/webtools.php
+++ b/webtools.php
@@ -19,7 +19,7 @@
 */
 
 use Phalcon\Web\Tools;
-
+define("APP_DIRECTORY", __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR);
 require 'webtools.config.php';
 require PTOOLSPATH . '/scripts/Phalcon/Web/Tools.php';
 


### PR DESCRIPTION
At now code use path app/, but i have another tree of folders, and i don't have app folder. That is why i try visit page webtools.php?_url=/migrations I  have error Warning: mkdir(): No such file or directory. This error present in  \vendor\phalcon\devtools\scripts\Phalcon\Web\Tools\controllers\MigrationsController.php on line 34 
This constants will used in MigrationsController.php on line 34