### PR TITLE
Changed path to migration directory

### DIFF
--- a/scripts/Phalcon/Web/Tools/controllers/MigrationsController.php
+++ b/scripts/Phalcon/Web/Tools/controllers/MigrationsController.php
@@ -29,7 +29,7 @@ class MigrationsController extends ControllerBase
      */
     protected function _getMigrationsDir()
     {
-        $migrationsDir = 'app/migrations';
+        $migrationsDir = APP_DIRECTORY.'migrations';
         if (!file_exists($migrationsDir)) {
             mkdir($migrationsDir);
         }


### PR DESCRIPTION
APP_DIRECTORY = this is constant which we set in webtools.php define("APP_DIRECTORY", __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR); 
I should use this because I don't have app/ foldaer.