### PR TITLE
Fix broken paths when using config.ini

### DIFF
--- a/scripts/Phalcon/Web/Tools.php
+++ b/scripts/Phalcon/Web/Tools.php
@@ -214,13 +214,11 @@ class Tools
             define('TEMPLATE_PATH', $path . '/templates');
         }
 
-        chdir('..');
-
         // Read configuration
         $configPaths = array(
-            'config',
-            'app/config',
-            'apps/frontend/config'
+            '../config',
+            '../app/config',
+            '../apps/frontend/config'
         );
 
         $readed = false;


### PR DESCRIPTION
When using config.ini (option --use-config-ini) the paths are set to one extra level up.