### PR TITLE
Fix of Phalcon\Builder\Component::_getConfig() output

### DIFF
--- a/scripts/Phalcon/Builder/Component.php
+++ b/scripts/Phalcon/Builder/Component.php
@@ -63,8 +63,11 @@ abstract class Component
             } else {
                 if (file_exists($path . $configPath. "/config.php")) {
                     $config = include($path . $configPath . "/config.php");
+                    if (!is_array($config)) {
+                        throw new BuilderException("config.php must return an array, to use in this context");
+                    }
 
-                    return $config;
+                    return new \Phalcon\Config($config);
                 }
             }
         }


### PR DESCRIPTION
Fix of Phalcon\Builder\Component::_getConfig() output (when config.php is used), as it should return an instance of Phalcon\Config, instead of array
