### PR TITLE
Fixes issue where model classes are not generated...

### DIFF
--- a/scripts/Phalcon/Builder/AllModels.php
+++ b/scripts/Phalcon/Builder/AllModels.php
@@ -196,6 +196,7 @@ class AllModels extends Component
                     'foreignKeys' => $foreignKeysModel,
                     'genSettersGetters' => $genSettersGetters,
                     'directory' => $this->_options['directory'],
+                    'modelsDir' => $this->_options['modelsDir'],
                 ));
 
                 $modelBuilder->build();

--- a/scripts/Phalcon/Commands/Builtin/AllModels.php
+++ b/scripts/Phalcon/Commands/Builtin/AllModels.php
@@ -102,7 +102,8 @@ class AllModels extends Command implements CommandsInterface
             'foreignKeys' => $this->isReceivedOption('fk'),
             'defineRelations' => $this->isReceivedOption('relations'),
             'genSettersGetters' => $this->isReceivedOption('get-set'),
-            'genDocMethods' => $this->isReceivedOption('doc')
+            'genDocMethods' => $this->isReceivedOption('doc'),
+            'modelsDir' => $modelsDir,
         ));
 
         $modelBuilder->build();


### PR DESCRIPTION
... even when "models" argument is still present.

The following error is thrown when the config file does not have an [application] section (and a "modelsDir" key in it):
Builder doesn't knows where is the models directory