### PR TITLE
Fix default path for Controllers creation

### DIFF
--- a/scripts/Phalcon/Builder/Controller.php
+++ b/scripts/Phalcon/Builder/Controller.php
@@ -60,7 +60,7 @@ class Controller extends Component
      */
     public function build()
     {
-        $path = '';
+        $path = realpath('..') . '/';
         if (isset($this->_options['directory']) && $this->_options['directory']) {
             $path = $this->_options['directory'] . '/';
         }

--- a/scripts/Phalcon/Web/Tools/controllers/MigrationsController.php
+++ b/scripts/Phalcon/Web/Tools/controllers/MigrationsController.php
@@ -29,7 +29,8 @@ class MigrationsController extends ControllerBase
      */
     protected function _getMigrationsDir()
     {
-        $migrationsDir = 'app/migrations';
+        $path = realpath('..') . '/';
+        $migrationsDir = $path . 'app/migrations';
         if (!file_exists($migrationsDir)) {
             mkdir($migrationsDir);
         }


### PR DESCRIPTION
This is a simple fix for an issue that prevents the ControllersController from loading the app config and using the configured controllersDir.

The default path is an empty string, therefore unusable to get the path to the config.
Since the root dir is "public", the simplest way is to go up one dir and append '/', allowing a proper load for the config file.