### PR TITLE
better condition in scripts/Phalcon/Builder/Model.php

### DIFF
--- a/scripts/Phalcon/Builder/Model.php
+++ b/scripts/Phalcon/Builder/Model.php
@@ -245,10 +245,10 @@ class Model extends Component
 
         $config = $this->_getConfig($path);
 
-        if (!isset($this->_options['modelsDir'])) {
+        if (!isset($this->_options['modelsDir']) || !file_exists($this->_options['modelsDir'])) {
             if (!isset($config->application->modelsDir)) {
                 throw new BuilderException(
-                    "Builder doesn't knows where is the models directory"
+                    "Builder doesn't know where is the models' directory"
                 );
             }
             $modelsDir = $config->application->modelsDir;


### PR DESCRIPTION
I was getting the error:

![screen shot 2015-03-04 at 18 29 50](https://cloud.githubusercontent.com/assets/3394457/6490486/8febd06c-c29e-11e4-86a4-22e64d605944.png)

### Note: phalcon-models is just an alias that I did to generate all the models and its relationships

, but this just happened on these last commits, I tried to understand the code, and came to the conclusion that on line 248 the condition becomes false, indeed, because `$this->_options['modelsDir']` is actually set but the path doesn't really exist.
The right path is set on line 254:

        $modelsDir = $config->application->modelsDir;


Then the result is,

![screen shot 2015-03-04 at 18 42 43](https://cloud.githubusercontent.com/assets/3394457/6490500/b7259870-c29e-11e4-9245-1969bbf565f9.png)

# it's worth to mention, I tried it on a Mac and Gnu/Linux Machine (Ubuntu distro to be precise)...
Windows guys,...sorry.. I don't care...
---
Hope, it helps someone..I was getting in panic...