### PR TITLE
improve scaffold with textarea on TEXT columns. Remove date type for TEXT

### DIFF
--- a/scripts/Phalcon/Builder/Scaffold.php
+++ b/scripts/Phalcon/Builder/Scaffold.php
@@ -399,7 +399,7 @@ class Scaffold extends Component
                     $code .= PHP_EOL . "\t\t\t\t" . '<?php echo $this->tag->textField(array("' . $attribute . '", "type" => "date")) ?>';
                     break;
                 case Column::TYPE_TEXT:
-                    $code .= PHP_EOL . "\t\t\t\t" . '<?php echo $this->tag->textField(array("' . $attribute . '", "type" => "date")) ?>';
+                    $code .= PHP_EOL . "\t\t\t\t" . '<?php echo $this->tag->textArea(array("' . $attribute . '", "cols" => 30, "rows" => 4)) ?>';
                     break;
                 default:
                     $code .= PHP_EOL . "\t\t\t" . '<?php echo $this->tag->textField(array("' . $attribute . '", "size" => 30)) ?>';
@@ -446,7 +446,7 @@ class Scaffold extends Component
                     $code .= PHP_EOL . "\t\t\t\t" . '{{ text_field("' . $attribute . '", "type" : "date") }}';
                     break;
                 case Column::TYPE_TEXT:
-                    $code .= PHP_EOL . "\t\t\t\t" . '{{ text_field("' . $attribute . '", "type" : "date") }}';
+                    $code .= PHP_EOL . "\t\t\t\t" . '{{ text_area("' . $attribute . '", "cols": "30", "rows": "4") }}';
                     break;
                 default:
                     $code .= PHP_EOL . "\t\t\t" . '{{ text_field("' . $attribute . '", "size" : 30) }}';


### PR DESCRIPTION
For some reason the TEXT column was being assigned to a `type="date"` in the [Scaffold component](https://github.com/phalcon/phalcon-devtools/blob/221045950e70ed9674e3f6de9e10c630c858a693/scripts/Phalcon/Builder/Scaffold.php#L402). This change turns any TEXT column into a textarea field.

Results: 

```php
<?php echo $this->tag->textArea(array("column_name", "cols" => 30, "rows" => 4)) ?>
```