### PR TITLE
add support for enum in scaffolding

### DIFF
--- a/scripts/Phalcon/Builder/Scaffold.php
+++ b/scripts/Phalcon/Builder/Scaffold.php
@@ -388,6 +388,9 @@ class Scaffold extends Component
         } else {
 
             switch ($dataType) {
+                case 5: // enum
+                    $code .= PHP_EOL . "\t\t\t\t" . '<?php echo $this->tag->selectStatic(array("' . $attribute . '", array())) ?>';
+                    break;
                 case Column::TYPE_CHAR:
                     $code .= PHP_EOL . "\t\t\t\t" . '<?php echo $this->tag->textField(array("' . $attribute . '")) ?>';
                     break;
@@ -435,6 +438,9 @@ class Scaffold extends Component
         } else {
 
             switch ($dataType) {
+                case 5: // enum
+                    $code .= PHP_EOL . "\t\t\t\t" . '{{ select_static("' . $attribute . '", "using": []) }}';
+                    break;
                 case Column::TYPE_CHAR:
                     $code .= PHP_EOL . "\t\t\t\t" . '{{ text_field("' . $attribute . '") }}';
                     break;


### PR DESCRIPTION
Out of all the `Column::TYPE_*` methods, there is no `ENUM`. Doing some debugging, it looks like enum is represented as **5**. This PR adds support for adding a `staticSelect` field when an enum field is detected.

Here are the results for the PHP template. The field is served an empty array, not sure if there is a way to grab the field enum values, but that would be awesome.

```php
<?php echo $this->tag->selectStatic(array("column_name", array())) ?>
```