### PR TITLE
Improved config detection

### DIFF
--- a/scripts/Phalcon/Builder/Component.php
+++ b/scripts/Phalcon/Builder/Component.php
@@ -4,7 +4,7 @@
   +------------------------------------------------------------------------+
   | Phalcon Developer Tools                                                |
   +------------------------------------------------------------------------+
-  | Copyright (c) 2011-2014 Phalcon Team (http://www.phalconphp.com)       |
+  | Copyright (c) 2011-2015 Phalcon Team (http://www.phalconphp.com)       |
   +------------------------------------------------------------------------+
   | This source file is subject to the New BSD License that is bundled     |
   | with this package in the file docs/LICENSE.txt.                        |
@@ -15,24 +15,26 @@
   +------------------------------------------------------------------------+
   | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
   |          Eduar Carvajal <eduar@phalconphp.com>                         |
+  |          Serghei Iakovlev <sadhooklay@gmail.com>                       |
   +------------------------------------------------------------------------+
 */
 
 namespace Phalcon\Builder;
 
 use Phalcon\Script\Color;
-use Phalcon\Builder\BuilderException;
+use Phalcon\Config;
+use Phalcon\Config\Adapter\Ini as ConfigIni;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 
 /**
- * \Phalcon\Builder\Component
+ * Abstract Component
  *
  * Base class for builder components
  *
- * @category 	Phalcon
- * @package 	Builder
- * @subpackage  Component
- * @copyright   Copyright (c) 2011-2014 Phalcon Team (team@phalconphp.com)
- * @license 	New BSD License
+ * @package     Phalcon\Builder
+ * @copyright   Copyright (c) 2011-2015 Phalcon Team (team@phalconphp.com)
+ * @license     New BSD License
  */
 abstract class Component
 {
@@ -50,21 +52,23 @@ abstract class Component
     /**
      * Tries to find the current configuration in the application
      *
-     * @param $path
+     * @param string $path Project path
      *
-     * @return mixed|\Phalcon\Config\Adapter\Ini
-     * @throws \Phalcon\Builder\BuilderException
+     * @return mixed|Config|ConfigIni
+     * @throws BuilderException
      */
     protected function _getConfig($path)
     {
+        $path = realpath($path) . DIRECTORY_SEPARATOR;
+
         foreach (array('app/config/', 'config/') as $configPath) {
-            if (file_exists($path . $configPath . "/config.ini")) {
-                return new \Phalcon\Config\Adapter\Ini($path . $configPath . "/config.ini");
+            if (file_exists($path . $configPath . 'config.ini')) {
+                return new ConfigIni($path . $configPath . 'config.ini');
             } else {
-                if (file_exists($path . $configPath. "/config.php")) {
-                    $config = include($path . $configPath . "/config.php");
+                if (file_exists($path . $configPath. 'config.php')) {
+                    $config = include($path . $configPath . 'config.php');
                     if (is_array($config)) {
-                        $config = new \Phalcon\Config($config);
+                        $config = new Config($config);
                     }
 
                     return $config;
@@ -72,29 +76,30 @@ abstract class Component
             }
         }
 
-        $directory = new \RecursiveDirectoryIterator('.');
-        $iterator = new \RecursiveIteratorIterator($directory);
+        $directory = new RecursiveDirectoryIterator('.');
+        $iterator = new RecursiveIteratorIterator($directory);
         foreach ($iterator as $f) {
             if (preg_match('/config\.php$/i', $f->getPathName())) {
                 $config = include $f->getPathName();
                 if (is_array($config)) {
-                    $config = new \Phalcon\Config($config);
+                    $config = new Config($config);
                 }
 
                 return $config;
             } else {
                 if (preg_match('/config\.ini$/i', $f->getPathName())) {
-                    return new \Phalcon\Config\Adapter\Ini($f->getPathName());
+                    return new ConfigIni($f->getPathName());
                 }
             }
         }
+
         throw new BuilderException('Builder can\'t locate the configuration file');
     }
 
     /**
      * Check if a path is absolute
      *
-     * @param $path
+     * @param string $path Project path
      *
      * @return bool
      */
@@ -120,20 +125,24 @@ abstract class Component
      */
     public function isConsole()
     {
-        return !isset($_SERVER['SERVER_SOFTWARE']);
+        return PHP_SAPI == 'cli';
     }
 
     /**
      * Check if the current adapter is supported by Phalcon
      *
-     * @param  string                            $adapter
-     * @throws \Phalcon\Builder\BuilderException
+     * @param  string $adapter
+     *
+     * @return bool
+     * @throws BuilderException
      */
     public function isSupportedAdapter($adapter)
     {
         if (!class_exists('\Phalcon\Db\Adapter\Pdo\\' . $adapter)) {
             throw new BuilderException("Adapter $adapter is not supported");
         }
+
+        return true;
     }
 
     /**
@@ -147,5 +156,4 @@ abstract class Component
     }
 
     abstract public function build();
-
 }


### PR DESCRIPTION
This PR fixed wrong config detect behaviour:

```php
// For example
$path = '.';

protected function _getConfig($path)
{
    // ...
    foreach (array('app/config/', 'config/') as $configPath) {
        if (file_exists($path . $configPath . "/config.ini")) {
            // ./app/config//config.ini
            // ./config//config.ini
        }
    }
    // ...
}
```