### PR TITLE
Fix project generator

### DIFF
--- a/scripts/Phalcon/Commands/Command.php
+++ b/scripts/Phalcon/Commands/Command.php
@@ -304,13 +304,14 @@ abstract class Command implements CommandsInterface
 
     /**
      * Returns the value of an option received. If more parameters are taken as filters.
-     * @param      $option
-     * @param null $filters
-     * @param null $defaultValue
      *
-     * @return mixed|null
+     * @param mixed $option Option name or array of options
+     * @param mixed $filters Filter name or array of filters
+     * @param mixed $defaultValue Default value [Optional]
+     *
+     * @return mixed
      */
-    public function getOption($option, $filters=null, $defaultValue=null)
+    public function getOption($option, $filters = null, $defaultValue = null)
     {
         if (is_array($option)) {
             foreach ($option as $optionItem) {


### PR DESCRIPTION
Now project generator can create path recursive (project type + project name).
For example:

```sh
$ phalcon project --name MyShop --directory=simle --trace --enable-webtools --use-config-ini >/dev/null 2>&1
$ phalcon project --name MyBlog --directory=simle --trace --enable-webtools --use-config-ini >/dev/null 2>&1
$ ls -l simle/
total 8
drwxrwxr-x 5 klay klay 4096 May  2 14:44 MyBlog
drwxrwxr-x 5 klay klay 4096 May  2 14:44 MyShop


```