### PR TITLE
fix DbAdapter param according to expected value

### DIFF
--- a/templates/project/micro/services.php
+++ b/templates/project/micro/services.php
@@ -34,5 +34,5 @@ $di->set('url', function () use ($config) {
  * Database connection is created based in the parameters defined in the configuration file
  */
 $di->set('db', function () use ($config) {
-    return new DbAdapter($config->toArray());
+    return new DbAdapter($config->database->toArray());
 });


### PR DESCRIPTION
**DbAdapter** expected as param something like this
```
    array(
        'adapter'    => 'Mysql',
        'host'       => 'localhost',
        'username'   => 'root',
        'password'   => 'root',
        'dbname'     => 'my_db_name',
        'charset'    => 'utf8',
    );
```
without **database->** part, it is passing the entire config array and when we try to execute a phql statement/query, it throws a php notice like this:
```
Notice: Array to string conversion in config/services.php on line 32
```