### PR TITLE
Added support for build phalcon.phar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 .DS_Store
+phalcon.phar

--- a/README.md
+++ b/README.md
@@ -61,6 +61,22 @@ ln -s ~/devtools/phalcon.php /usr/bin/phalcon
 chmod ugo+x /usr/bin/phalcon
 ```
 
+## Build `.phar`
+
+Install composer and box in a common location or in your project:
+```bash
+curl -s http://getcomposer.org/installer | php
+bin/composer install
+```
+
+Build phar file `phalcon-devtools`
+```bash
+bin/box build -v
+chmod +xr ./phalcon.phar
+# Test it!
+php ./phalcon.phar
+```
+
 ## Installation via PEAR
 
 Phalcon Devtools can be installed using PEAR. Since the current version of Devtools

--- a/box.json
+++ b/box.json
@@ -1,0 +1,24 @@
+{
+  "directories": "resources",
+  "files": "webtools.php",
+  "finder": [
+    {
+      "exclude": [
+        "CONTRIBUTING.md",
+        "README.md",
+        "LICENSE",
+        "phalcon.bat",
+        "phalcon.sh"
+      ],
+      "in": "scripts",
+      "name": [
+        "*.phtml",
+        "*.php"
+      ]
+    }
+  ],
+  "git-version": "git_tag",
+  "main": "phalcon.php",
+  "output": "phalcon.phar",
+  "stub": true
+}

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "phalcon/devtools",
     "type": "library",
     "description": "This tools provide you useful scripts to generate code helping to develop faster and easy applications that use with Phalcon framework.",
-    "keywords": ["framework", "phalcon", "devtools", "webtools"],
+    "keywords": ["framework", "phalcon", "devtools", "webtools", "phar"],
     "homepage": "http://phalconphp.com",
     "license": "BSD-3",
     "authors": [
@@ -14,6 +14,9 @@
     "require": {
         "php": ">=5.3.9",
         "ext-phalcon": "~2.0"
+    },
+    "require-dev": {
+        "box": ">=2.5.2",
     },
     "autoload": {
         "psr-0" : {


### PR DESCRIPTION
###### [Box](http://box-project.org/) application for building and managing _.phar_
Brings the ability of the package as a PHP archive file (phar).
- Declare obsolete scripts `phalcon.bat`, `phalcon.sh`.
```bash
$ box build -v
* Building...
? Output path: .../phalcon-devtools/phalcon.phar
? Setting replacement values...
  + @git_tag@: v2.0.1-76-gfcf2253
? Adding Finder files...
  + .../phalcon-devtools/scripts/...
? Adding files...
  + .../phalcon-devtools/webtools.php
? Adding main file: .../phalcon-devtools/phalcon.php
? Generating new stub...
* Done.

$ chmod +xr ./phalcon.phar

$ mv -v phalcon{.phar,}
phalcon.phar -> phalcon

$ file ./phalcon
./phalcon: a php script text executable

$ ./phalcon
Phalcon DevTools (2.0.1)

Available commands:
  commands (alias of: list, enumerate)
  controller (alias of: create-controller)
  model (alias of: create-model)
  all-models (alias of: create-all-models)
  project (alias of: create-project)
  scaffold (alias of: create-scaffold)
  migration (alias of: create-migration)
  webtools (alias of: create-webtools)
```
