### PR TITLE
Fix phalcon model --excludefields option

### DIFF
--- a/scripts/Phalcon/Builder/Model.php
+++ b/scripts/Phalcon/Builder/Model.php
@@ -433,18 +433,19 @@ class Model extends Component
         $setters = array();
         $getters = array();
         foreach ($fields as $field) {
+            if (array_key_exists(strtolower($field->getName()), $exclude)) {
+                continue;
+            }
             $type = $this->getPHPType($field->getType());
             if ($useSettersGetters) {
-                if (!array_key_exists(strtolower($field->getName()), $exclude)) {
-                    $attributes[] = $this->snippet->getAttributes($type, 'protected', $field->getName());
-                    $setterName = Utils::camelize($field->getName());
-                    $setters[] = $this->snippet->getSetter($field->getName(), $type, $setterName);
+                $attributes[] = $this->snippet->getAttributes($type, 'protected', $field->getName());
+                $setterName = Utils::camelize($field->getName());
+                $setters[] = $this->snippet->getSetter($field->getName(), $type, $setterName);
 
-                    if (isset($this->_typeMap[$type])) {
-                        $getters[] = $this->snippet->getGetterMap($field->getName(), $type, $setterName, $this->_typeMap[$type]);
-                    } else {
-                        $getters[] = $this->snippet->getGetter($field->getName(), $type, $setterName);
-                    }
+                if (isset($this->_typeMap[$type])) {
+                    $getters[] = $this->snippet->getGetterMap($field->getName(), $type, $setterName, $this->_typeMap[$type]);
+                } else {
+                    $getters[] = $this->snippet->getGetter($field->getName(), $type, $setterName);
                 }
             } else {
                 $attributes[] = $this->snippet->getAttributes($type, 'public', $field->getName());


### PR DESCRIPTION
Currently, --excludefields works only with --get-set option.
This PR fixes --excludefields behavior and enables to exclude fields without --get-set option.
This is re-submit of https://github.com/phalcon/phalcon-devtools/pull/432.