### PR TITLE
Adapt the php-dev-tools to work with oldest version of PHP < 5.4

### DIFF
--- a/scripts/Phalcon/Web/Tools.php
+++ b/scripts/Phalcon/Web/Tools.php
@@ -413,9 +413,16 @@ class Tools
             throw new \Exception('Document root cannot be located');
         }
 
-        (new Bootstrap())->uninstall($path);
-        (new CodeMirror())->uninstall($path);
-        (new JQuery())->uninstall($path);
+
+        $bootstrap = new Bootstrap();
+        $bootstrap->uninstall($path);
+
+        $codeMirror = new CodeMirror();
+        $codeMirror->uninstall($path);
+
+        $jQuery = new JQuery();
+        $jQuery->uninstall($path);
+
 
         if (is_file($path . 'public/webtools.config.php')) {
             unlink($path . 'public/webtools.config.php');

--- a/scripts/Phalcon/Web/Tools.php
+++ b/scripts/Phalcon/Web/Tools.php
@@ -373,9 +373,14 @@ class Tools
             throw new \Exception('Document root cannot be located');
         }
 
-        (new Bootstrap())->install($path);
-        (new CodeMirror())->install($path);
-        (new JQuery())->install($path);
+        $bootstrap = new Bootstrap();
+        $bootstrap->install($path);
+
+        $codeMirror = new CodeMirror();
+        $codeMirror->install($path);
+
+        $jQuery = new JQuery();
+        $jQuery->install($path);
 
         copy($tools . '/webtools.php', $path . 'public/webtools.php');
 


### PR DESCRIPTION
A small change that allows operation even in older versions, instantiating the class before calling the method of the same.

**Resend on branch