### PR TITLE
Profiler documentation for getProfiles method fix

### DIFF
--- a/ide/2.0.0/Phalcon/db/Profiler.php
+++ b/ide/2.0.0/Phalcon/db/Profiler.php
@@ -60,7 +60,7 @@ class Profiler
     /**
      * Returns all the processed profiles
      *
-     * @return \Phalcon\Db\Profiler\Item 
+     * @return \Phalcon\Db\Profiler\Item[] 
      */
 	public function getProfiles() {}
 


### PR DESCRIPTION
In fact that getProfiles returns all the processed profiles as an array of \Phalcon\Db\Profiler\Item