### PR TITLE
fixed the path error of webtools page

### DIFF
--- a/scripts/Phalcon/Web/Tools/controllers/ControllerBase.php
+++ b/scripts/Phalcon/Web/Tools/controllers/ControllerBase.php
@@ -177,7 +177,7 @@ class ControllerBase extends Controller
         $config = Tools::getConfig()->offsetGet('application');
 
         $dirs = array('modelsDir', 'controllersDir', 'migrationsDir');
-        $this->path->setRootPath(dirname(getcwd()));
+        $this->path->setRootPath(dirname($_SERVER["SCRIPT_FILENAME"]));
         $projectPath = $this->path->getRootPAth();
 
         foreach ($dirs as $dirName) {


### PR DESCRIPTION
the correct path is the path of file "webtools.php",  not the path of the project root.   when i create project with devtools and enable webtools,  the "webtools.php" file is in the public dir.