### PR TITLE
Add standard error output

### DIFF
--- a/phalcon.pear
+++ b/phalcon.pear
@@ -79,7 +79,9 @@ try {
 
     $script->run();
 } catch (PhalconException $e) {
-    print Color::error($e->getMessage()) . PHP_EOL;
+    fwrite(STDERR, Color::error($e->getMessage()) . PHP_EOL);
+    exit(1);
 } catch (Exception $e) {
-    print 'ERROR: ' . $e->getMessage() . PHP_EOL;
+    fwrite(STDERR, 'ERROR: ' . $e->getMessage() . PHP_EOL);
+    exit(1);
 }

--- a/phalcon.php
+++ b/phalcon.php
@@ -80,7 +80,9 @@ try {
 
     $script->run();
 } catch (PhalconException $e) {
-    print Color::error($e->getMessage()) . PHP_EOL;
+    fwrite(STDERR, Color::error($e->getMessage()) . PHP_EOL);
+    exit(1);
 } catch (Exception $e) {
-    print 'ERROR: ' . $e->getMessage() . PHP_EOL;
+    fwrite(STDERR, 'ERROR: ' . $e->getMessage() . PHP_EOL);
+    exit(1);
 }


### PR DESCRIPTION
### Currently
`phalcon command` outputs STDOUT(standard output) even if it throws the exception.

So below doesn't work correctly.
```sh
$ phalcon invalid-command 2> stderr.log
```

### Should
outputs STDERR(standard error) when an error happened.