### PR TITLE
Added create-module comand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .idea
 .DS_Store
 phalcon.phar
+composer.lock
+composer.phar
+/vendor/

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ $ phalcon commands help
 This command should display something similar to:
 
 ```bash
+$ phalcon list ?
+
 Phalcon DevTools (2.0.9)
 
 Help:
@@ -111,6 +113,7 @@ Help:
 Available commands:
   commands         (alias of: list, enumerate)
   controller       (alias of: create-controller)
+  module           (alias of: create-module)
   model            (alias of: create-model)
   all-models       (alias of: create-all-models)
   project          (alias of: create-project)
@@ -160,4 +163,4 @@ $config = [
 Phalcon Developer Tools is open source software licensed under the [New BSD License][1].
 © Phalcon Framework Team and contributors
 
-[1]: https://github.com/phalcon/phalcon-devtools/blob/master/docs/LICENSE.md
+[1]: docs/LICENSE.md

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         "kherge/box": ">=2.5.2"
     },
     "autoload": {
-        "psr-0" : {
-            "Phalcon" : "scripts/"
+        "psr-4" : {
+            "Phalcon\\" : "scripts/Phalcon/"
         }
     },
     "bin": ["phalcon.php"]

--- a/phalcon.php
+++ b/phalcon.php
@@ -66,6 +66,7 @@ try {
     $commandsToEnable = array(
         '\Phalcon\Commands\Builtin\Enumerate',
         '\Phalcon\Commands\Builtin\Controller',
+        '\Phalcon\Commands\Builtin\Module',
         '\Phalcon\Commands\Builtin\Model',
         '\Phalcon\Commands\Builtin\AllModels',
         '\Phalcon\Commands\Builtin\Project',

--- a/scripts/Phalcon/Builder/Model.php
+++ b/scripts/Phalcon/Builder/Model.php
@@ -58,10 +58,10 @@ class Model extends Component
      * @param array $options Builder options
      * @throws BuilderException
      */
-    public function __construct(array $options = array())
+    public function __construct(array $options)
     {
         if (!isset($options['name'])) {
-            throw new BuilderException("Please, specify the model name");
+            throw new BuilderException('Please, specify the model name');
         }
 
         if (!isset($options['force'])) {
@@ -118,6 +118,12 @@ class Model extends Component
         }
     }
 
+    /**
+     * Module build
+     *
+     * @return mixed
+     * @throws \Phalcon\Builder\BuilderException
+     */
     public function build()
     {
         if (!$this->options->contains('name')) {
@@ -131,10 +137,11 @@ class Model extends Component
         $config = $this->getConfig();
 
         if (!$modelsDir = $this->options->get('modelsDir')) {
-            if (!isset($config->application->modelsDir)) {
+            if (!$config->get('application') || !isset($config->get('application')->modelsDir)) {
                 throw new BuilderException("Builder doesn't know where is the models directory.");
             }
-            $modelsDir = $config->application->modelsDir;
+
+            $modelsDir = $config->get('application')->modelsDir;
         }
 
         $modelsDir = rtrim($modelsDir, '/\\') . DIRECTORY_SEPARATOR;

--- a/scripts/Phalcon/Builder/Module.php
+++ b/scripts/Phalcon/Builder/Module.php
@@ -1,0 +1,265 @@
+<?php
+
+/*
+  +------------------------------------------------------------------------+
+  | Phalcon Developer Tools                                                |
+  +------------------------------------------------------------------------+
+  | Copyright (c) 2011-2015 Phalcon Team (http://www.phalconphp.com)       |
+  +------------------------------------------------------------------------+
+  | This source file is subject to the New BSD License that is bundled     |
+  | with this package in the file docs/LICENSE.txt.                        |
+  |                                                                        |
+  | If you did not receive a copy of the license and are unable to         |
+  | obtain it through the world-wide-web, please send an email             |
+  | to license@phalconphp.com so we can send you a copy immediately.       |
+  +------------------------------------------------------------------------+
+  | Authors: Serghei Iakovlev <serghei@phalconphp.com>                     |
+  +------------------------------------------------------------------------+
+*/
+
+namespace Phalcon\Builder;
+
+/**
+ * Module Builder
+ *
+ * Builder to create module skeletons
+ *
+ * @package     Phalcon\Builder
+ * @copyright   Copyright (c) 2011-2015 Phalcon Team (team@phalconphp.com)
+ * @license     New BSD License
+ */
+class Module extends Component
+{
+    protected $moduleDirectories = array(
+        'config',
+        'controllers',
+        'models',
+        'views',
+    );
+
+    /**
+     * Stores variable values depending on parameters
+     * @var array
+     */
+    protected $variableValues = array();
+
+    /**
+     * Create Builder object
+     *
+     * @param array $options Builder options
+     * @throws BuilderException
+     */
+    public function __construct(array $options)
+    {
+        parent::__construct($options);
+
+
+    }
+
+    /**
+     * Module build
+     *
+     * @return mixed
+     * @throws \Phalcon\Builder\BuilderException
+     */
+    public function build()
+    {
+        if (!$this->options->contains('name')) {
+            throw new BuilderException('Please, specify the model name');
+        }
+
+        $templatePath = str_replace('scripts/' . str_replace('\\', DIRECTORY_SEPARATOR, __CLASS__) . '.php', '', __FILE__)
+            . 'templates' . DIRECTORY_SEPARATOR . 'module';
+
+        if ($this->options->contains('templatePath')) {
+            $templatePath = $this->options->get('templatePath');
+        }
+
+        if ($this->options->contains('directory')) {
+            $this->path->setRootPath($this->options->get('directory'));
+        }
+
+        $config = $this->getConfig();
+
+        if (!$modulesDir = $this->options->get('modulesDir')) {
+            if (!$config->get('application') || !isset($config->get('application')->modulesDir)) {
+                throw new BuilderException("Builder doesn't know where is the modules directory.");
+            }
+
+            $modulesDir = $config->get('application')->modulesDir;
+        }
+
+        $modulesDir = rtrim($modulesDir, '/\\') . DIRECTORY_SEPARATOR;
+        if (false == $this->isAbsolutePath($modulesDir)) {
+            $modulesDir = $this->path->getRootPath($modulesDir);
+        }
+
+        $this->options->offsetSet('modulesDir', realpath($modulesDir));
+        $this->options->offsetSet('templatePath', realpath($templatePath));
+        $this->options->offsetSet('projectPath', $this->path->getRootPath());
+
+        $this
+            ->buildDirectories()
+            ->getVariableValues()
+            ->createConfig()
+            ->createModule();
+
+        $this->_notifySuccess(sprintf(
+            'Module "%s" was successfully created.',
+            $this->options->get('name')
+        ));
+    }
+
+    /**
+     * Build project directories
+     *
+     * @return $this
+     * @throws BuilderException
+     */
+    public function buildDirectories()
+    {
+        $modulesDir = $this->options->get('modulesDir');
+        $moduleName = $this->options->get('name');
+
+        if (file_exists($modulesDir . DIRECTORY_SEPARATOR . $moduleName)) {
+            throw new BuilderException(sprintf(
+                'The Module "%s" already exists in modules dir',
+                $moduleName
+            ));
+        }
+
+        mkdir($modulesDir . DIRECTORY_SEPARATOR . $moduleName, 0777, true);
+
+        foreach ($this->moduleDirectories as $dir) {
+            mkdir($modulesDir . DIRECTORY_SEPARATOR . $moduleName . DIRECTORY_SEPARATOR . $dir, 0777, true);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Generate file $putFile from $getFile, replacing @@variableValues@@
+     *
+     * @param string $getFile From file
+     * @param string $putFile To file
+     * @param string $name
+     * @param string $namespace
+     *
+     * @return $this
+     */
+    protected function generateFile($getFile, $putFile, $name = '', $namespace = '')
+    {
+        if (false == file_exists($putFile)) {
+            touch($putFile);
+            $fh = fopen($putFile, "w+");
+
+            $str = file_get_contents($getFile);
+
+            if (!$namespace && $name) {
+                $namespace = $name;
+            }
+
+            if ($namespace) {
+                // default is reserved keyword
+                if (strtolower(trim($namespace)) == 'default') {
+                    $namespace = 'MyDefault';
+                }
+
+                $namespace = ucfirst($namespace);
+            }
+
+
+            if ($name && 0 != strcasecmp($namespace, $name)) {
+                $namespacePart = $name;
+
+                // default is reserved keyword
+                if (strtolower(trim($namespacePart)) == 'default') {
+                    $namespacePart = 'MyDefault';
+                }
+
+                $namespace = $namespace . '\\' . ucfirst($namespacePart);
+            }
+
+            $str = preg_replace('/@@name@@/', $name, $str);
+            $str = preg_replace('/@@FQMN@@/', $namespace, $str);
+
+            if (count($this->variableValues) > 0) {
+                foreach ($this->variableValues as $variableValueKey => $variableValue) {
+                    $variableValueKeyRegEx = '/@@'.preg_quote($variableValueKey, '/').'@@/';
+                    $str = preg_replace($variableValueKeyRegEx, $variableValue, $str);
+                }
+            }
+
+            fwrite($fh, $str);
+            fclose($fh);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Generate variable values depending on parameters
+     *
+     * return $this
+     */
+    protected function getVariableValues()
+    {
+        $variableValuesResult = array();
+        $variablesJsonFile = $this->options->get('templatePath') . DIRECTORY_SEPARATOR . 'variables.json';
+
+        if (file_exists($variablesJsonFile)) {
+            $variableValues = json_decode(file_get_contents($variablesJsonFile), true);
+            if ($variableValues) {
+                foreach ($this->options as $k => $option) {
+                    if (!isset($variableValues[$k])) {
+                        continue;
+                    }
+
+                    $variableValuesResult = $variableValues[$k][$option];
+                }
+            }
+
+            $this->variableValues = $variableValuesResult;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Create Module
+     *
+     * @return $this
+     */
+    private function createModule()
+    {
+        $modulesDir = $this->options->get('modulesDir');
+        $moduleName = $this->options->get('name');
+        $namespace  = $this->options->get('namespace');
+
+        $getFile = $this->options->get('templatePath')  . DIRECTORY_SEPARATOR . 'Module.php';
+        $putFile = $modulesDir . DIRECTORY_SEPARATOR . $moduleName . DIRECTORY_SEPARATOR . 'Module.php';
+
+        $this->generateFile($getFile, $putFile, $moduleName, $namespace);
+
+        return $this;
+    }
+
+    /**
+     * Creates the configuration
+     *
+     * @return $this
+     */
+    private function createConfig()
+    {
+        $type = $this->options->get('config-type', 'php');
+        $modulesDir = $this->options->get('modulesDir');
+        $moduleName = $this->options->get('name');
+        $namespace  = $this->options->get('namespace');
+
+        $getFile = $this->options->get('templatePath')  . DIRECTORY_SEPARATOR . 'config.' . $type;
+        $putFile = $modulesDir . DIRECTORY_SEPARATOR . $moduleName . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR . 'config.' . $type;
+        $this->generateFile($getFile, $putFile, $moduleName, $namespace);
+
+        return $this;
+    }
+}

--- a/scripts/Phalcon/Builder/Project.php
+++ b/scripts/Phalcon/Builder/Project.php
@@ -21,7 +21,7 @@
 namespace Phalcon\Builder;
 
 /**
- * Project
+ * Project Builder
  *
  * Builder to create application skeletons
  *
@@ -40,7 +40,7 @@ class Project extends Component
      * Current Project Type
      * @var null
      */
-    private $currentType = null;
+    private $currentType = self::TYPE_SIMPLE;
 
     /**
      * Available Project Types
@@ -52,18 +52,6 @@ class Project extends Component
         self::TYPE_MODULES => '\Phalcon\Builder\Project\Modules',
         self::TYPE_CLI     => '\Phalcon\Builder\Project\Cli',
     );
-
-    /**
-     * Create Builder object
-     *
-     * @param array $options Builder options
-     */
-    public function __construct(array $options = array())
-    {
-        $this->currentType = self::TYPE_SIMPLE;
-
-        parent::__construct($options);
-    }
 
     /**
      * Project build
@@ -86,7 +74,7 @@ class Project extends Component
             throw new BuilderException('Projects cannot be created inside Phalcon projects.');
         }
 
-        $this->currentType = $this->options->get('type', self::TYPE_SIMPLE);
+        $this->currentType = $this->options->get('type');
 
         if (!isset($this->_types[$this->currentType])) {
             throw new BuilderException(sprintf(

--- a/scripts/Phalcon/Builder/Project/Modules.php
+++ b/scripts/Phalcon/Builder/Project/Modules.php
@@ -163,7 +163,7 @@ class Modules extends ProjectBuilder
     }
 
     /**
-     * Create ControllerBase
+     * Create Module
      *
      * @return $this
      */

--- a/scripts/Phalcon/Builder/Project/ProjectBuilder.php
+++ b/scripts/Phalcon/Builder/Project/ProjectBuilder.php
@@ -37,7 +37,7 @@ abstract class ProjectBuilder
      * Stores variable values depending on parameters
      * @var array
      */
-    protected $variableValues;
+    protected $variableValues = array();
 
     /**
      * Builder options

--- a/scripts/Phalcon/Commands/Builtin/AllModels.php
+++ b/scripts/Phalcon/Commands/Builtin/AllModels.php
@@ -144,16 +144,6 @@ class AllModels extends Command
     }
 
     /**
-     * Checks whether the command can be executed outside a Phalcon project
-     *
-     * @return boolean
-     */
-    public function canBeExternal()
-    {
-        return false;
-    }
-
-    /**
      * {@inheritdoc}
      *
      * @return void

--- a/scripts/Phalcon/Commands/Builtin/AllModels.php
+++ b/scripts/Phalcon/Commands/Builtin/AllModels.php
@@ -64,13 +64,13 @@ class AllModels extends Command
     }
 
     /**
-     * Executes the command
+     * {@inheritdoc}
      *
-     * @param $parameters
-     * @return void
+     * @param array $parameters
+     * @return mixed
      * @throws CommandsException
      */
-    public function run($parameters)
+    public function run(array $parameters)
     {
         if ($this->isReceivedOption('directory')) {
             if (false == $this->path->isAbsolutePath($this->getOption('directory'))) {

--- a/scripts/Phalcon/Commands/Builtin/AllModels.php
+++ b/scripts/Phalcon/Commands/Builtin/AllModels.php
@@ -154,7 +154,7 @@ class AllModels extends Command
     }
 
     /**
-     * Prints the help for current command.
+     * {@inheritdoc}
      *
      * @return void
      */

--- a/scripts/Phalcon/Commands/Builtin/AllModels.php
+++ b/scripts/Phalcon/Commands/Builtin/AllModels.php
@@ -134,7 +134,7 @@ class AllModels extends Command
     }
 
     /**
-     * Returns the commands provided by the command
+     * {@inheritdoc}
      *
      * @return array
      */
@@ -154,7 +154,7 @@ class AllModels extends Command
     }
 
     /**
-     * Returns number of required parameters for this command
+     * {@inheritdoc}
      *
      * @return integer
      */

--- a/scripts/Phalcon/Commands/Builtin/Controller.php
+++ b/scripts/Phalcon/Commands/Builtin/Controller.php
@@ -76,7 +76,7 @@ class Controller extends Command
     }
 
     /**
-     * Returns the command identifier
+     * {@inheritdoc}
      *
      * @return array
      */
@@ -106,7 +106,7 @@ class Controller extends Command
     }
 
     /**
-     * Returns number of required parameters for this command
+     * {@inheritdoc}
      *
      * @return integer
      */

--- a/scripts/Phalcon/Commands/Builtin/Controller.php
+++ b/scripts/Phalcon/Commands/Builtin/Controller.php
@@ -94,7 +94,7 @@ class Controller extends Command
     }
 
     /**
-     * Prints the help for current command.
+     * {@inheritdoc}
      *
      * @return void
      */

--- a/scripts/Phalcon/Commands/Builtin/Controller.php
+++ b/scripts/Phalcon/Commands/Builtin/Controller.php
@@ -86,14 +86,6 @@ class Controller extends Command
     }
 
     /**
-     * Checks whether the command can be executed outside a Phalcon project
-     */
-    public function canBeExternal()
-    {
-        return false;
-    }
-
-    /**
      * {@inheritdoc}
      *
      * @return void

--- a/scripts/Phalcon/Commands/Builtin/Controller.php
+++ b/scripts/Phalcon/Commands/Builtin/Controller.php
@@ -54,12 +54,12 @@ class Controller extends Command
     }
 
     /**
-     * Executes the command
+     * {@inheritdoc}
      *
-     * @param $parameters
-     * @return string
+     * @param array $parameters
+     * @return mixed
      */
-    public function run($parameters)
+    public function run(array $parameters)
     {
         $controllerName = $this->getOption(array('name', 1));
 

--- a/scripts/Phalcon/Commands/Builtin/Enumerate.php
+++ b/scripts/Phalcon/Commands/Builtin/Enumerate.php
@@ -69,7 +69,7 @@ class Enumerate extends Command
     }
 
     /**
-     * Returns the commands provided by the command
+     * {@inheritdoc}
      *
      * @return array
      */
@@ -102,7 +102,7 @@ class Enumerate extends Command
     }
 
     /**
-     * Returns number of required parameters for this command
+     * {@inheritdoc}
      *
      * @return integer
      */

--- a/scripts/Phalcon/Commands/Builtin/Enumerate.php
+++ b/scripts/Phalcon/Commands/Builtin/Enumerate.php
@@ -45,12 +45,12 @@ class Enumerate extends Command
     }
 
     /**
-     * Executes the command
+     * {@inheritdoc}
      *
-     * @param $parameters
-     * @return void
+     * @param array $parameters
+     * @return mixed
      */
-    public function run($parameters)
+    public function run(array $parameters)
     {
         print Color::colorize('Available commands:', Color::FG_BROWN) . PHP_EOL;
         foreach ($this->getScript()->getCommands() as $commands) {

--- a/scripts/Phalcon/Commands/Builtin/Enumerate.php
+++ b/scripts/Phalcon/Commands/Builtin/Enumerate.php
@@ -79,7 +79,7 @@ class Enumerate extends Command
     }
 
     /**
-     * Checks whether the command can be executed outside a Phalcon project
+     * {@inheritdoc}
      *
      * @return boolean
      */

--- a/scripts/Phalcon/Commands/Builtin/Enumerate.php
+++ b/scripts/Phalcon/Commands/Builtin/Enumerate.php
@@ -89,7 +89,7 @@ class Enumerate extends Command
     }
 
     /**
-     * Prints help on the usage of the command
+     * {@inheritdoc}
      *
      * @return void
      */

--- a/scripts/Phalcon/Commands/Builtin/Migration.php
+++ b/scripts/Phalcon/Commands/Builtin/Migration.php
@@ -138,7 +138,7 @@ class Migration extends Command
     }
 
     /**
-     * Returns the command identifier
+     * {@inheritdoc}
      *
      * @return array
      */
@@ -171,7 +171,7 @@ class Migration extends Command
     }
 
     /**
-     * Returns number of required parameters for this command
+     * {@inheritdoc}
      *
      * @return integer
      */

--- a/scripts/Phalcon/Commands/Builtin/Migration.php
+++ b/scripts/Phalcon/Commands/Builtin/Migration.php
@@ -148,14 +148,6 @@ class Migration extends Command
     }
 
     /**
-     * Checks whether the command can be executed outside a Phalcon project
-     */
-    public function canBeExternal()
-    {
-        return false;
-    }
-
-    /**
      * {@inheritdoc}
      *
      * @return void

--- a/scripts/Phalcon/Commands/Builtin/Migration.php
+++ b/scripts/Phalcon/Commands/Builtin/Migration.php
@@ -156,7 +156,7 @@ class Migration extends Command
     }
 
     /**
-     * Prints the help for current command.
+     * {@inheritdoc}
      *
      * @return void
      */

--- a/scripts/Phalcon/Commands/Builtin/Migration.php
+++ b/scripts/Phalcon/Commands/Builtin/Migration.php
@@ -62,12 +62,12 @@ class Migration extends Command
     }
 
     /**
-     * Executes the command
+     * {@inheritdoc}
      *
-     * @param $parameters
-     * @return void
+     * @param array $parameters
+     * @return mixed
      */
-    public function run($parameters)
+    public function run(array $parameters)
     {
         if ($this->isReceivedOption('table')) {
             $tableName = $this->getOption('table');

--- a/scripts/Phalcon/Commands/Builtin/Model.php
+++ b/scripts/Phalcon/Commands/Builtin/Model.php
@@ -99,7 +99,7 @@ class Model extends Command
     }
 
     /**
-     * Returns the commands provided by the command
+     * {@inheritdoc}
      *
      * @return array
      */
@@ -129,7 +129,7 @@ class Model extends Command
     }
 
     /**
-     * Returns number of required parameters for this command
+     * {@inheritdoc}
      *
      * @return int
      */

--- a/scripts/Phalcon/Commands/Builtin/Model.php
+++ b/scripts/Phalcon/Commands/Builtin/Model.php
@@ -119,7 +119,7 @@ class Model extends Command
     }
 
     /**
-     * Prints the help for current command.
+     * {@inheritdoc}
      *
      * @return void
      */

--- a/scripts/Phalcon/Commands/Builtin/Model.php
+++ b/scripts/Phalcon/Commands/Builtin/Model.php
@@ -62,12 +62,12 @@ class Model extends Command
     }
 
     /**
-     * Executes the command
+     * {@inheritdoc}
      *
-     * @param $parameters
-     * @return void
+     * @param array $parameters
+     * @return mixed
      */
-    public function run($parameters)
+    public function run(array $parameters)
     {
         $name = $this->getOption(array('name', 1));
 

--- a/scripts/Phalcon/Commands/Builtin/Model.php
+++ b/scripts/Phalcon/Commands/Builtin/Model.php
@@ -109,16 +109,6 @@ class Model extends Command
     }
 
     /**
-     * Checks whether the command can be executed outside a Phalcon project
-     *
-     * @return boolean
-     */
-    public function canBeExternal()
-    {
-        return false;
-    }
-
-    /**
      * {@inheritdoc}
      *
      * @return void

--- a/scripts/Phalcon/Commands/Builtin/Module.php
+++ b/scripts/Phalcon/Commands/Builtin/Module.php
@@ -21,6 +21,7 @@
 namespace Phalcon\Commands\Builtin;
 
 use Phalcon\Commands\Command;
+use Phalcon\Script\Color;
 
 /**
  * Module Command
@@ -65,13 +66,16 @@ class Module extends Command
     }
 
     /**
-     * Prints the help for current command.
+     * {@inheritdoc}
      *
      * @return void
      */
     public function getHelp()
     {
+        print Color::head('Help:') . PHP_EOL;
+        print Color::colorize('  Creates a module') . PHP_EOL . PHP_EOL;
 
+        $this->run(array());
     }
 
     /**
@@ -81,7 +85,7 @@ class Module extends Command
      */
     public function getRequiredParams()
     {
-
+        return 1;
     }
 
     /**

--- a/scripts/Phalcon/Commands/Builtin/Module.php
+++ b/scripts/Phalcon/Commands/Builtin/Module.php
@@ -45,12 +45,12 @@ class Module extends Command
     }
 
     /**
-     * Executes the command
+     * {@inheritdoc}
      *
-     * @param $parameters
-     * @return void
+     * @param array $parameters
+     * @return mixed
      */
-    public function run($parameters)
+    public function run(array $parameters)
     {
 
     }

--- a/scripts/Phalcon/Commands/Builtin/Module.php
+++ b/scripts/Phalcon/Commands/Builtin/Module.php
@@ -13,8 +13,7 @@
   | obtain it through the world-wide-web, please send an email             |
   | to license@phalconphp.com so we can send you a copy immediately.       |
   +------------------------------------------------------------------------+
-  | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
-  |          Eduar Carvajal <eduar@phalconphp.com>                         |
+  | Authors: Serghei Iakovlev <serghei@phalconphp.com>                     |
   +------------------------------------------------------------------------+
 */
 

--- a/scripts/Phalcon/Commands/Builtin/Module.php
+++ b/scripts/Phalcon/Commands/Builtin/Module.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+  +------------------------------------------------------------------------+
+  | Phalcon Developer Tools                                                |
+  +------------------------------------------------------------------------+
+  | Copyright (c) 2011-2015 Phalcon Team (http://www.phalconphp.com)       |
+  +------------------------------------------------------------------------+
+  | This source file is subject to the New BSD License that is bundled     |
+  | with this package in the file docs/LICENSE.txt.                        |
+  |                                                                        |
+  | If you did not receive a copy of the license and are unable to         |
+  | obtain it through the world-wide-web, please send an email             |
+  | to license@phalconphp.com so we can send you a copy immediately.       |
+  +------------------------------------------------------------------------+
+  | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+  |          Eduar Carvajal <eduar@phalconphp.com>                         |
+  +------------------------------------------------------------------------+
+*/
+
+namespace Phalcon\Commands\Builtin;
+
+use Phalcon\Commands\Command;
+
+/**
+ * Module Command
+ *
+ * Create a module from command line
+ *
+ * @package     Phalcon\Commands\Builtin
+ * @copyright   Copyright (c) 2011-2015 Phalcon Team (team@phalconphp.com)
+ * @license     New BSD License
+ */
+class Module extends Command
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @return array
+     */
+    public function getPossibleParams()
+    {
+        return array();
+    }
+
+    /**
+     * Executes the command
+     *
+     * @param $parameters
+     * @return void
+     */
+    public function run($parameters)
+    {
+
+    }
+
+    /**
+     * Returns the command identifier
+     *
+     * @return array
+     */
+    public function getCommands()
+    {
+        return array('module', 'create-module');
+    }
+
+    /**
+     * Prints the help for current command.
+     *
+     * @return void
+     */
+    public function getHelp()
+    {
+
+    }
+
+    /**
+     * Returns number of required parameters for this command
+     *
+     * @return integer
+     */
+    public function getRequiredParams()
+    {
+
+    }
+
+    /**
+     * Checks whether the command can be executed outside a Phalcon project
+     *
+     * @return boolean
+     */
+    public function canBeExternal()
+    {
+        return false;
+    }
+}

--- a/scripts/Phalcon/Commands/Builtin/Module.php
+++ b/scripts/Phalcon/Commands/Builtin/Module.php
@@ -22,6 +22,7 @@ namespace Phalcon\Commands\Builtin;
 
 use Phalcon\Commands\Command;
 use Phalcon\Script\Color;
+use Phalcon\Builder\Module as ModuleBuilder;
 
 /**
  * Module Command
@@ -41,7 +42,15 @@ class Module extends Command
      */
     public function getPossibleParams()
     {
-        return array();
+        return array(
+            'name'            => 'Name of the new module',
+            'namespace=s'     => "Module's namespace [optional]",
+            'output=s'        => 'Folder where modules are located [optional]',
+            'config-type=s'   => 'The config type to be generated (ini, json, php, yaml) [optional]',
+            'template-path=s' => 'Specify a template path [optional]',
+            'help'            => 'Shows this help [optional]',
+
+        );
     }
 
     /**
@@ -52,17 +61,41 @@ class Module extends Command
      */
     public function run(array $parameters)
     {
+        $moduleName   = $this->getOption(array('name', 1));
+        $namespace    = $this->getOption('namespace', null, 'Application');
+        $configType   = $this->getOption('config-type', null, 'php');
+        $modulesDir   = $this->getOption('output');
+        $templatePath = $this->getOption('template-path', null, TEMPLATE_PATH . DIRECTORY_SEPARATOR . 'module');
 
+        $builder = new ModuleBuilder(array(
+            'name'         => $moduleName,
+            'namespace'    => $namespace,
+            'config-type'  => $configType,
+            'templatePath' => $templatePath,
+            'modulesDir'   => $modulesDir
+        ));
+
+        return $builder->build();
     }
 
     /**
-     * Returns the command identifier
+     * {@inheritdoc}
      *
      * @return array
      */
     public function getCommands()
     {
         return array('module', 'create-module');
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return boolean
+     */
+    public function canBeExternal()
+    {
+        return false;
     }
 
     /**
@@ -75,26 +108,19 @@ class Module extends Command
         print Color::head('Help:') . PHP_EOL;
         print Color::colorize('  Creates a module') . PHP_EOL . PHP_EOL;
 
-        $this->run(array());
+        print Color::head('Example') . PHP_EOL;
+        print Color::colorize('  phalcon module backend', Color::FG_GREEN) . PHP_EOL . PHP_EOL;
+
+        $this->printParameters($this->getPossibleParams());
     }
 
     /**
-     * Returns number of required parameters for this command
+     * {@inheritdoc}
      *
      * @return integer
      */
     public function getRequiredParams()
     {
         return 1;
-    }
-
-    /**
-     * Checks whether the command can be executed outside a Phalcon project
-     *
-     * @return boolean
-     */
-    public function canBeExternal()
-    {
-        return false;
     }
 }

--- a/scripts/Phalcon/Commands/Builtin/Project.php
+++ b/scripts/Phalcon/Commands/Builtin/Project.php
@@ -82,7 +82,7 @@ class Project extends Command
     }
 
     /**
-     * Returns the command identifier
+     * {@inheritdoc}
      *
      * @return array
      */
@@ -125,7 +125,7 @@ class Project extends Command
     }
 
     /**
-     * Returns number of required parameters for this command
+     * {@inheritdoc}
      *
      * @return integer
      */

--- a/scripts/Phalcon/Commands/Builtin/Project.php
+++ b/scripts/Phalcon/Commands/Builtin/Project.php
@@ -102,7 +102,7 @@ class Project extends Command
     }
 
     /**
-     * Prints the help for current command.
+     * {@inheritdoc}
      *
      * @return void
      */

--- a/scripts/Phalcon/Commands/Builtin/Project.php
+++ b/scripts/Phalcon/Commands/Builtin/Project.php
@@ -64,7 +64,7 @@ class Project extends Command
     {
         $projectName = $this->getOption(array('name', 1), null, 'default');
         $projectType = $this->getOption(array('type', 2), null, 'simple');
-        $projectPath = $this->getOption(array('directory', 3), null, '');
+        $projectPath = $this->getOption(array('directory', 3));
         $templatePath = $this->getOption(array('template-path'), null, TEMPLATE_PATH);
         $enableWebtools = $this->getOption(array('enable-webtools', 4), null, false);
         $useConfigIni = $this->getOption('use-config-ini');

--- a/scripts/Phalcon/Commands/Builtin/Project.php
+++ b/scripts/Phalcon/Commands/Builtin/Project.php
@@ -92,7 +92,7 @@ class Project extends Command
     }
 
     /**
-     * Checks whether the command can be executed outside a Phalcon project
+     * {@inheritdoc}
      *
      * @return boolean
      */

--- a/scripts/Phalcon/Commands/Builtin/Project.php
+++ b/scripts/Phalcon/Commands/Builtin/Project.php
@@ -55,12 +55,12 @@ class Project extends Command
     }
 
     /**
-     * Executes the current command
+     * {@inheritdoc}
      *
-     * @param  array $parameters
-     * @return boolean
+     * @param array $parameters
+     * @return mixed
      */
-    public function run($parameters)
+    public function run(array $parameters)
     {
         $projectName = $this->getOption(array('name', 1), null, 'default');
         $projectType = $this->getOption(array('type', 2), null, 'simple');

--- a/scripts/Phalcon/Commands/Builtin/Scaffold.php
+++ b/scripts/Phalcon/Commands/Builtin/Scaffold.php
@@ -106,7 +106,7 @@ class Scaffold extends Command
     }
 
     /**
-     * Prints help on the usage of the command
+     * {@inheritdoc}
      *
      * @return void
      */

--- a/scripts/Phalcon/Commands/Builtin/Scaffold.php
+++ b/scripts/Phalcon/Commands/Builtin/Scaffold.php
@@ -86,7 +86,7 @@ class Scaffold extends Command
     }
 
     /**
-     * Returns the command identifier
+     * {@inheritdoc}
      *
      * @return array
      */
@@ -116,7 +116,7 @@ class Scaffold extends Command
     }
 
     /**
-     * Returns number of required parameters for this command
+     * {@inheritdoc}
      *
      * @return integer
      */

--- a/scripts/Phalcon/Commands/Builtin/Scaffold.php
+++ b/scripts/Phalcon/Commands/Builtin/Scaffold.php
@@ -96,16 +96,6 @@ class Scaffold extends Command
     }
 
     /**
-     * Checks whether the command can be executed outside a Phalcon project
-     *
-     * @return boolean
-     */
-    public function canBeExternal()
-    {
-        return false;
-    }
-
-    /**
      * {@inheritdoc}
      *
      * @return void

--- a/scripts/Phalcon/Commands/Builtin/Scaffold.php
+++ b/scripts/Phalcon/Commands/Builtin/Scaffold.php
@@ -58,12 +58,12 @@ class Scaffold extends Command
     }
 
     /**
-     * Executes the current command
+     * {@inheritdoc}
      *
-     * @param $parameters
-     * @return boolean
+     * @param array $parameters
+     * @return mixed
      */
-    public function run($parameters)
+    public function run(array $parameters)
     {
         $name = $this->getOption(array('table-name', 1));
         $templatePath = $this->getOption(array('template-path'), null, TEMPLATE_PATH);

--- a/scripts/Phalcon/Commands/Builtin/Webtools.php
+++ b/scripts/Phalcon/Commands/Builtin/Webtools.php
@@ -102,7 +102,7 @@ class Webtools extends Command
     }
 
     /**
-     * Print the help on the usage of the command
+     * {@inheritdoc}
      *
      * @return void
      */

--- a/scripts/Phalcon/Commands/Builtin/Webtools.php
+++ b/scripts/Phalcon/Commands/Builtin/Webtools.php
@@ -92,16 +92,6 @@ class Webtools extends Command
     }
 
     /**
-     * Check whether the command can be executed outside a Phalcon project
-     *
-     * @return boolean
-     */
-    public function canBeExternal()
-    {
-        return false;
-    }
-
-    /**
      * {@inheritdoc}
      *
      * @return void

--- a/scripts/Phalcon/Commands/Builtin/Webtools.php
+++ b/scripts/Phalcon/Commands/Builtin/Webtools.php
@@ -82,7 +82,7 @@ class Webtools extends Command
     }
 
     /**
-     * Return the commands provided by the command
+     * {@inheritdoc}
      *
      * @return array
      */
@@ -115,7 +115,7 @@ class Webtools extends Command
     }
 
     /**
-     * Return the number of required parameters for this command
+     * {@inheritdoc}
      *
      * @return integer
      */

--- a/scripts/Phalcon/Commands/Builtin/Webtools.php
+++ b/scripts/Phalcon/Commands/Builtin/Webtools.php
@@ -49,13 +49,13 @@ class Webtools extends Command
     }
 
     /**
-     * Executes the command
+     * {@inheritdoc}
      *
-     * @param  array $parameters
+     * @param array $parameters
+     * @return mixed
      * @throws CommandsException
-     * @return void
      */
-    public function run($parameters)
+    public function run(array $parameters)
     {
         $action = $this->getOption(array('action', 1));
         $directory = './';

--- a/scripts/Phalcon/Commands/Command.php
+++ b/scripts/Phalcon/Commands/Command.php
@@ -449,7 +449,17 @@ abstract class Command implements CommandsInterface
      */
     public function isReceivedOption($option)
     {
-        return isset($this->_parameters[$option]);
+        if (!is_array($option)) {
+            $option = [$option];
+        }
+
+        foreach ($option as $op) {
+            if (isset($this->_parameters[$op])) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/scripts/Phalcon/Commands/Command.php
+++ b/scripts/Phalcon/Commands/Command.php
@@ -550,7 +550,7 @@ abstract class Command implements CommandsInterface
     }
 
     /**
-     * Checks whether the command has identifier
+     * {@inheritdoc}
      *
      * @param string $identifier
      *

--- a/scripts/Phalcon/Commands/Command.php
+++ b/scripts/Phalcon/Commands/Command.php
@@ -532,7 +532,7 @@ abstract class Command implements CommandsInterface
     /**
      * Returns the processed parameters
      *
-     * @return string
+     * @return array
      */
     public function getParameters()
     {

--- a/scripts/Phalcon/Commands/Command.php
+++ b/scripts/Phalcon/Commands/Command.php
@@ -540,7 +540,7 @@ abstract class Command implements CommandsInterface
     }
 
     /**
-     * By default all commands must be external
+     * {@inheritdoc}
      *
      * @return boolean
      */

--- a/scripts/Phalcon/Commands/CommandsInterface.php
+++ b/scripts/Phalcon/Commands/CommandsInterface.php
@@ -35,10 +35,10 @@ interface CommandsInterface
     /**
      * Executes the command
      *
-     * @param $parameters
+     * @param array $parameters
      * @return mixed
      */
-    public function run($parameters);
+    public function run(array $parameters);
 
     /**
      * Returns the command identifier

--- a/scripts/Phalcon/Commands/CommandsInterface.php
+++ b/scripts/Phalcon/Commands/CommandsInterface.php
@@ -33,7 +33,7 @@ namespace Phalcon\Commands;
 interface CommandsInterface
 {
     /**
-     * Executes the command
+     * Executes the command.
      *
      * @param array $parameters
      * @return mixed
@@ -41,7 +41,7 @@ interface CommandsInterface
     public function run(array $parameters);
 
     /**
-     * Returns the command identifier
+     * Returns the command identifier.
      *
      * @return array
      */
@@ -55,21 +55,21 @@ interface CommandsInterface
     public function canBeExternal();
 
     /**
-     * Prints help on the usage of the command
+     * Prints help on the usage of the command.
      *
      * @return void
      */
     public function getHelp();
 
     /**
-     * Return required parameters
+     * Return required parameters.
      *
      * @return integer
      */
     public function getRequiredParams();
 
     /**
-     * Checks whether the command has identifier
+     * Checks whether the command has identifier.
      *
      * @param string $identifier
      *
@@ -78,7 +78,7 @@ interface CommandsInterface
     public function hasIdentifier($identifier);
 
     /**
-     * Gets possible command parameters
+     * Gets possible command parameters.
      *
      * This method returns a list of available parameters for the current command.
      * The list must be represented as pairs key-value.

--- a/scripts/Phalcon/Commands/CommandsInterface.php
+++ b/scripts/Phalcon/Commands/CommandsInterface.php
@@ -48,7 +48,7 @@ interface CommandsInterface
     public function getCommands();
 
     /**
-     * Checks whether the command can be executed outside a Phalcon project
+     * Checks whether the command can be executed outside a Phalcon project.
      *
      * @return boolean
      */

--- a/scripts/Phalcon/Commands/CommandsListener.php
+++ b/scripts/Phalcon/Commands/CommandsListener.php
@@ -50,12 +50,11 @@ class CommandsListener
         }
 
         $parameters = $command->parseParameters();
+
         if (
             count($parameters) < ($command->getRequiredParams() + 1) ||
-            $command->isReceivedOption('help') ||
-            $command->getOption(1) == 'help' ||
-            $command->isReceivedOption('?') ||
-            $command->getOption(1) == '?'
+            $command->isReceivedOption(['help', '?']) ||
+            in_array($command->getOption(1), ['help', '?'])
         ) {
             $command->getHelp();
 

--- a/scripts/Phalcon/Script.php
+++ b/scripts/Phalcon/Script.php
@@ -110,6 +110,12 @@ class Script
         return $this->_commands;
     }
 
+    /**
+     * Dispatch the Command
+     *
+     * @param Command $command
+     * @return bool
+     */
     public function dispatch(Command $command)
     {
         // If beforeCommand fails abort

--- a/scripts/Phalcon/Web/Tools.php
+++ b/scripts/Phalcon/Web/Tools.php
@@ -370,20 +370,23 @@ class Tools
      *
      * @param  string     $path
      * @return bool
-     * @throws \Exception if document root cannot be located
+     * @throws Exception if document root cannot be located
      */
     public static function install($path)
     {
         $path = realpath($path) . DIRECTORY_SEPARATOR;
-        $tools = realpath(__DIR__ . '/../../../');
 
-        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
-            $path = str_replace("\\", '/', $path);
-            $tools = str_replace("\\", '/', $tools);
+        if (!$tools = getenv('PTOOLSPATH')) {
+            $tools = realpath(__DIR__ . '/../../../');
         }
 
-        if (!is_dir($path . 'public/')) {
-            throw new \Exception('Document root cannot be located');
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+            $path = str_replace("\\", DIRECTORY_SEPARATOR, $path);
+            $tools = str_replace("\\", DIRECTORY_SEPARATOR, $tools);
+        }
+
+        if (!is_dir($path . 'public' . DIRECTORY_SEPARATOR)) {
+            throw new Exception('Document root cannot be located');
         }
 
         $bootstrap = new Bootstrap();

--- a/scripts/Phalcon/Web/Tools/controllers/ControllersController.php
+++ b/scripts/Phalcon/Web/Tools/controllers/ControllersController.php
@@ -29,8 +29,8 @@ class ControllersController extends ControllerBase
     {
         if (!$this->controllersDir) {
             $this->flash->error(
-                "Sorry, WebTools doesn't know where is the controllers directory. <br>" .
-                "Please add to <code>application</code> section <code>controllersDir</code> param with valid path."
+                "Sorry, WebTools doesn't know where the controllers directory is.<br>" .
+                "Please add the valid path for <code>controllersDir</code> in the <code>application</code> section."
             );
         }
 
@@ -134,7 +134,7 @@ class ControllersController extends ControllerBase
             }
 
             if (!is_writable($this->controllersDir . $fileName)) {
-                $this->flash->error('Controller file does not has write access.');
+                $this->flash->error('Controller file does not have write access.');
 
                 return $this->dispatcher->forward(array(
                     'controller' => 'controllers',

--- a/scripts/Phalcon/Web/Tools/controllers/ScaffoldController.php
+++ b/scripts/Phalcon/Web/Tools/controllers/ScaffoldController.php
@@ -28,8 +28,8 @@ class ScaffoldController extends ControllerBase
     {
         $errorMessage = function ($directoryName, $directoryPath) {
             return sprintf(
-                "Sorry, WebTools doesn't know where is the %s directory. <br>" .
-                "Please add to <code>application</code> section <code>%s</code> param with valid path.",
+                "Sorry, WebTools doesn't know wherethe %s directory is.<br>" .
+                "Please add the valid path for  <code>%s</code> in the <code>application</code> section <code>%s</code>.",
                 $directoryName,
                 $directoryPath
             );

--- a/scripts/Phalcon/Web/Tools/views/controllers/list.phtml
+++ b/scripts/Phalcon/Web/Tools/views/controllers/list.phtml
@@ -31,8 +31,8 @@
                     <tr class="warning">
                         <td colspan="4">
                             <p class="text-center lead">
-                                Sorry, WebTools doesn't know where is the controllers directory. <br>
-                                Please add to <code>application</code> section <code>controllersDir</code> param with valid path.
+                                Sorry, WebTools doesn't know where the controllers directory is.<br>
+                                Please add the valid path for <code>controllersDir</code> in the <code>application</code> section.
                             </p>
                         </td>
                     </tr>

--- a/scripts/Phalcon/Web/Tools/views/index/index.phtml
+++ b/scripts/Phalcon/Web/Tools/views/index/index.phtml
@@ -8,5 +8,5 @@
 <div class="welcome-phalcon">
     <h1>Welcome to WebTools</h1>
 
-    <p class="lead">This application allow you to use <a href="http://www.phalconphp.com" target="_blank">Phalcon</a> Developer Tools using a web interface</p>
+    <p class="lead">This application allows you to use <a href="http://www.phalconphp.com" target="_blank">Phalcon</a> Developer Tools using a web interface.</p>
 </div>

--- a/scripts/Phalcon/Web/Tools/views/migrations/index.phtml
+++ b/scripts/Phalcon/Web/Tools/views/migrations/index.phtml
@@ -30,7 +30,7 @@
                 <div class="form-group disabled">
                     <label for="version" class="col-sm-4 control-label">New Version</label>
                     <div class="col-sm-8">
-                        <?php echo $this->tag->textField(array('version', 'placeholder' => 'Let empty to auto new version',  'class' => 'form-control', 'id' => 'version')) ?>
+                        <?php echo $this->tag->textField(array('version', 'placeholder' => 'Leave empty to automatically add new version',  'class' => 'form-control', 'id' => 'version')) ?>
                     </div>
                 </div>
 

--- a/scripts/Phalcon/Web/Tools/views/models/list.phtml
+++ b/scripts/Phalcon/Web/Tools/views/models/list.phtml
@@ -31,8 +31,8 @@
                 <tr class="warning">
                     <td colspan="4">
                         <p class="text-center lead">
-                            Sorry, WebTools doesn't know where is the models directory. <br>
-                            Please add to <code>application</code> section <code>modelsDir</code> param with valid path.
+                            Sorry, WebTools doesn't know where the models directory is.<br>
+                            Please add the valid path for <code>modelsDir</code> in the <code>application</code> section.
                         </p>
                     </td>
                 </tr>

--- a/templates/module/Module.php
+++ b/templates/module/Module.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace @@FQMN@@;
+
+use Phalcon\DiInterface;
+use Phalcon\Loader;
+use Phalcon\Mvc\View;
+use Phalcon\Mvc\ModuleDefinitionInterface;
+@@iniConfigImport@@
+@@useConfig@@
+
+class Module implements ModuleDefinitionInterface
+{
+    /**
+     * Registers an autoloader related to the module
+     *
+     * @param DiInterface $di
+     */
+    public function registerAutoloaders(DiInterface $di = null)
+    {
+        $loader = new Loader();
+
+        $loader->registerNamespaces(array(
+            '@@FQMN@@\Controllers' => __DIR__ . '/controllers/',
+            '@@FQMN@@\Models'      => __DIR__ . '/models/'
+        ));
+
+        $loader->register();
+    }
+
+    /**
+     * Registers services related to the module
+     *
+     * @param DiInterface $di
+     */
+    public function registerServices(DiInterface $di)
+    {
+        /**
+         * Read common configuration
+         */
+         $config = $di->has('config') ? $di->getShared('config') : null;
+
+        /**
+         * Try to load local configuration
+         */
+        if (file_exists(@@configName@@)) {
+            $override = @@configLoader@@;
+
+            if ($config instanceof Config) {
+                $config->merge($override);
+            } else {
+                $config = $override;
+            }
+        }
+
+        /**
+         * Setting up the view component
+         */
+        $di['view'] = function () use ($config) {
+            $view = new View();
+            $view->setViewsDir($config->get('application')->viewsDir);
+
+            return $view;
+        };
+
+        /**
+         * Database connection is created based in the parameters defined in the configuration file
+         */
+        $di['db'] = function () use ($config) {
+            $config = $config->database->toArray();
+
+            $dbAdapter = '\Phalcon\Db\Adapter\Pdo\\' . $config['adapter'];
+            unset($config['adapter']);
+
+            return new $dbAdapter($config);
+        };
+    }
+}

--- a/templates/module/config.ini
+++ b/templates/module/config.ini
@@ -1,0 +1,4 @@
+[application]
+controllersDir = @@name@@/controllers/
+modelsDir      = @@name@@/models/
+viewsDir       = @@name@@/views/

--- a/templates/module/config.json
+++ b/templates/module/config.json
@@ -1,0 +1,7 @@
+{
+  "application": {
+    "controllersDir": "@@name@@/controllers/",
+    "modelsDir": "@@name@@/models/",
+    "viewsDir": "@@name@@/views/"
+  }
+}

--- a/templates/module/config.php
+++ b/templates/module/config.php
@@ -1,0 +1,9 @@
+<?php
+
+return array(
+    'application' => array(
+        'controllersDir' => __DIR__ . '/../controllers/',
+        'modelsDir'      => __DIR__ . '/../models/',
+        'viewsDir'       => __DIR__ . '/../views/',
+    )
+);

--- a/templates/module/config.yaml
+++ b/templates/module/config.yaml
@@ -1,0 +1,4 @@
+application:
+    controllersDir: !local /controllers/
+    modelsDir: !local /models/
+    viewsDir: !local /views/

--- a/templates/module/variables.json
+++ b/templates/module/variables.json
@@ -1,0 +1,28 @@
+{
+  "config-type": {
+    "php": {
+      "configLoader": "new Config(include __DIR__ . '/config/config.php');",
+      "iniConfigImport": "use Phalcon\\Config;",
+      "configName": "__DIR__ . '/config/config.php'",
+      "useConfig": ""
+    },
+    "ini": {
+      "configLoader": "new Ini(__DIR__ . '/config/config.ini')",
+      "iniConfigImport": "use Phalcon\\Config\\Adapter\\Ini;",
+      "configName": "__DIR__ . '/config/config.ini'",
+      "useConfig": "use Phalcon\\Config;"
+    },
+    "yaml": {
+      "configLoader": "new Yaml(__DIR__ . '/config/config.yaml', array('!local' => function($value) { return __DIR__ . $value; }))",
+      "iniConfigImport": "use Phalcon\\Config\\Adapter\\Yaml;",
+      "configName": "__DIR__ . '/config/config.yaml'",
+      "useConfig": "use Phalcon\\Config;"
+    },
+    "json": {
+      "configLoader": "new Json(__DIR__ . '/config/config.json')",
+      "iniConfigImport": "use Phalcon\\Config\\Adapter\\Json;",
+      "configName": "__DIR__ . '/config/config.json'",
+      "useConfig": "use Phalcon\\Config;"
+    }
+  }
+}


### PR DESCRIPTION
+ Added `create-module comand` #108 
```
$ phalcon module 

Phalcon DevTools (2.0.9)

Help:
  Creates a module

Example
  phalcon module backend

Options:
 --name               Name of the new module
 --namespace=s        Module's namespace [optional]
 --output=s           Folder where modules are located [optional]
 --config-type=s      The config type to be generated (ini, json, php, yaml) [optional]
 --template-path=s    Specify a template path [optional]
 --help               Shows this help [optional]
```


+ Fixed grammar (#551)
+ Amended PHPDoc
+ Minor fixes