### PR TITLE
trying to load  the abstract base model class file with —extends para…

### DIFF
--- a/scripts/Phalcon/Builder/Model.php
+++ b/scripts/Phalcon/Builder/Model.php
@@ -336,6 +336,12 @@ class Model extends Component
 
                 $possibleMethods['getSource'] = true;
 
+                $extends = $this->options->get('extends', '\Phalcon\Mvc\Model');
+                $extendsPath = dirname($modelPath) . '/'. $extends . '.php';
+                if (file_exists($extendsPath)) {
+                    require_once $extendsPath;
+                }
+
                 require $modelPath;
 
                 $linesCode = file($modelPath);


### PR DESCRIPTION
Repeating the generated will trigger fatal error: Class 'x' not found in x on line x,when use —extends=BaseModel