### PR TITLE
Phalcon\Mvc\Model::find docblock bug

### DIFF
--- a/ide/2.0.9/Phalcon/mvc/Model.php
+++ b/ide/2.0.9/Phalcon/mvc/Model.php
@@ -363,8 +363,7 @@ abstract class Model implements \Phalcon\Mvc\EntityInterface, \Phalcon\Mvc\Model
      * }
      * </code>
      *
-     * @param mixed $parameters 
-     * @param  $array parameters
+     * @param string|array $parameters
      * @return \Phalcon\Mvc\Model\ResultsetInterface 
      */
     public static function find($parameters = null) {}


### PR DESCRIPTION
Docblock is formatted incorrectly for the Phalcon\Mvc\Model::find method.