### PR TITLE
Improve support for PDO Sqlite migrations

### DIFF
--- a/scripts/Phalcon/Migrations.php
+++ b/scripts/Phalcon/Migrations.php
@@ -400,7 +400,7 @@ class Migrations
             }
 
             if (!self::$_storage->tableExists('phalcon_migrations')) {
-                self::$_storage->execute("CREATE TABLE `phalcon_migrations` (`version` VARCHAR(255), `start_time` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, `end_time` TIMESTAMP NOT NULL DEFAULT '0000-00-00 00:00:00' NOT NULL);");
+                self::$_storage->execute("CREATE TABLE `phalcon_migrations` (`version` VARCHAR(255), `start_time` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, `end_time` TIMESTAMP NOT NULL DEFAULT '0000-00-00 00:00:00' NOT NULL)");
             }
 
         } else {
@@ -432,7 +432,7 @@ class Migrations
         if (isset($options['migrationsInDb']) && (bool)$options['migrationsInDb']) {
             /** @var AdapterInterface $connection */
             $connection = self::$_storage;
-            $lastGoodMigration = $connection->query('SELECT * FROM `phalcon_migrations` ORDER BY `version` DESC LIMIT 1;');
+            $lastGoodMigration = $connection->query('SELECT * FROM `phalcon_migrations` ORDER BY `version` DESC LIMIT 1');
             if (0 == $lastGoodMigration->numRows()) {
                 return VersionCollection::createItem(null);
             } else {
@@ -465,7 +465,7 @@ class Migrations
         if (isset($options['migrationsInDb']) && (bool)$options['migrationsInDb']) {
             /** @var AdapterInterface $connection */
             $connection = self::$_storage;
-            $connection->execute('INSERT INTO `phalcon_migrations` (`version`, `start_time`, `end_time`) VALUES ("' . $version . '", ' . $startTime . ', NOW());');
+            $connection->execute('INSERT INTO `phalcon_migrations` (`version`, `start_time`, `end_time`) VALUES ("' . $version . '", ' . $startTime . ', NOW())');
         } else {
             $currentVersions = self::getCompletedVersions($options);
             $currentVersions[(string)$version] = 1;
@@ -488,7 +488,7 @@ class Migrations
         if (isset($options['migrationsInDb']) && (bool)$options['migrationsInDb']) {
             /** @var AdapterInterface $connection */
             $connection = self::$_storage;
-            $connection->execute('DELETE FROM `phalcon_migrations` WHERE version="' . $version . '" LIMIT 1;');
+            $connection->execute('DELETE FROM `phalcon_migrations` WHERE version="' . $version . '" LIMIT 1');
         } else {
             $currentVersions = self::getCompletedVersions($options);
             unset($currentVersions[(string)$version]);
@@ -511,7 +511,7 @@ class Migrations
         if (isset($options['migrationsInDb']) && (bool)$options['migrationsInDb']) {
             /** @var AdapterInterface $connection */
             $connection = self::$_storage;
-            $completedVersions = $connection->query('SELECT `version` FROM `phalcon_migrations` ORDER BY `version` DESC;')->fetchAll();
+            $completedVersions = $connection->query('SELECT `version` FROM `phalcon_migrations` ORDER BY `version` DESC')->fetchAll();
             $completedVersions = array_map(function ($version) {
                 return $version['version'];
             }, $completedVersions);

--- a/scripts/Phalcon/Migrations.php
+++ b/scripts/Phalcon/Migrations.php
@@ -458,14 +458,19 @@ class Migrations
      * @param string $version Migration version to store
      * @param string $startTime Migration start timestamp
      */
-    public static function addCurrentVersion($options, $version, $startTime = 'NOW()')
+    public static function addCurrentVersion($options, $version, $startTime = null)
     {
         self::connectionSetup($options);
+
+        if ($startTime === null) {
+            $startTime = date('"Y-m-d H:i:s"');
+        }
+        $endTime = date('"Y-m-d H:i:s"');
 
         if (isset($options['migrationsInDb']) && (bool)$options['migrationsInDb']) {
             /** @var AdapterInterface $connection */
             $connection = self::$_storage;
-            $connection->execute('INSERT INTO `phalcon_migrations` (`version`, `start_time`, `end_time`) VALUES ("' . $version . '", ' . $startTime . ', NOW())');
+            $connection->execute('INSERT INTO `phalcon_migrations` (`version`, `start_time`, `end_time`) VALUES ("' . $version . '", ' . $startTime . ', ' . $endTime . ')');
         } else {
             $currentVersions = self::getCompletedVersions($options);
             $currentVersions[(string)$version] = 1;

--- a/scripts/Phalcon/Utils.php
+++ b/scripts/Phalcon/Utils.php
@@ -27,6 +27,8 @@ class Utils
 {
     const DB_ADAPTER_POSTGRESQL = 'Postgresql';
 
+    const DB_ADAPTER_SQLITE = 'Sqlite';
+
     /**
      * Converts the underscore_notation to the UpperCamelCase
      *
@@ -43,7 +45,7 @@ class Utils
 
     /**
      * Converts the underscore_notation to the lowerCamelCase
-     * 
+     *
      * @param string $string
      * @return string
      */
@@ -65,7 +67,13 @@ class Utils
         }
 
         if (self::DB_ADAPTER_POSTGRESQL == $config->get('adapter')) {
-            return  'public';
+            return 'public';
+        }
+
+        if (self::DB_ADAPTER_SQLITE == $config->get('adapter')) {
+            // SQLite only supports the current database, unless one is
+            // attached. This is not the case, so don't return a schema.
+            return null;
         }
 
         if ($config->offsetExists('dbname')) {


### PR DESCRIPTION
I know PDO SQLite migrations are not fully working (due to ALTER table limitations), but the following three commits should at least improve support for running migrations (I successfully converted structure from MySQL to SQLite).

* 2866803 fixes the issue described in PR #638.
* 3f543dc changes MySQL's `NOW()` in PHP's `date()`. The latter is already used in `Migrations.php`.
* 7e2c1cd fixes the issue where the file path is added as schema (see below).

Example of issue the last commit fixes (note the file name is used as schema in the CREATE TABLE statement):

```
1459346099.167: CREATE TABLE "/opt/backend/app/../data/df.db"."projects" (  `ID` INTEGER NOT NULL,  `name` VARCHAR(128) NOT NULL,  `userID` INTEGER NOT NULL,  `defaultQuestionID` INTEGER,  `access` VARCHAR(512),  `metadata` TEXT NOT NULL,  `created` DATETIME NOT NULL,  `modified` DATETIME,  `deleted` DATETIME,  PRIMARY KEY ("ID"),  CONSTRAINT `projects_ibfk_1` FOREIGN KEY ("userID") REFERENCES `users`("ID"),  CONSTRAINT `projects_ibfk_2` FOREIGN KEY ("defaultQuestionID") REFERENCES `questions`("ID") )PHP Fatal error:  Uncaught exception 'PDOException' with message 'SQLSTATE[HY000]: General error: 1 unknown database "/opt/backend/app/../data/df.db"' in /opt/backend/vendor/phalcon/devtools/scripts/Phalcon/Mvc/Model/Migration.php:663
```

I have also a patch ready that converts the missing column types for SQLite (Blob, Double, etc). I'll contribute this to CPhalcon.