### PR TITLE
Now the phalcon-devtools can call a loader file informed on project c…

### DIFF
--- a/scripts/Phalcon/Builder/Model.php
+++ b/scripts/Phalcon/Builder/Model.php
@@ -169,7 +169,11 @@ class Model extends Component
                 "Please specify a config variable [database][adapter]"
             );
         }
-
+        
+        if (isset($config->devtools->loader)) {
+            require $config->devtools->loader;
+        }
+        
         $namespace = '';
         if ($this->options->contains('namespace') && $this->checkNamespace($this->options->get('namespace'))) {
             $namespace = 'namespace '.$this->options->get('namespace').';'.PHP_EOL.PHP_EOL;


### PR DESCRIPTION
Now the phalcon-devtools can call a loader file informed on project config: 

I had the same issue as: https://github.com/phalcon/phalcon-devtools/issues/571

With this changes in devtools, I have added to my project config.php the property:

```php
    'devtools' => [
        'loader'      => APP_PATH . '/app/config/loader.php'
    ],
```

and in my project the loader.php is: 

```php 

$loader = new \Phalcon\Loader();

/**
 * We're a registering a set of directories taken from the configuration file
 */
$loader->registerDirs(
    array(
        $config->application->controllersDir,
        $config->application->libraryDir,
        $config->application->pluginsDir,
        $config->application->modelsDir,
//        $config->application->customHelpersDir
    )
)->register();

```
This Loader is used for entire app. A custom one could be made only for devtools.

Now, the devtools is able execute a loader to register any custom classes to use inside Models. 

Thanks.

