### PR TITLE
Volt, overriding callMacro renders error

### DIFF
--- a/ide/2.0.9/Phalcon/mvc/view/engine/Volt.php
+++ b/ide/2.0.9/Phalcon/mvc/view/engine/Volt.php
@@ -98,6 +98,6 @@ class Volt extends \Phalcon\Mvc\View\Engine implements \Phalcon\Mvc\View\EngineI
      * @param string $name 
      * @param array $arguments 
      */
-    public function callMacro($name, $arguments) {}
+    public function callMacro($name, array $arguments) {}
 
 }


### PR DESCRIPTION
Extending Volt class and overriding callMacro($name, $arguments) renders errors due to signature mismatch:
ErrorException: Declaration of Pow\Mvc\Volt::callMacro() should be compatible with Phalcon\Mvc\View\Engine\Volt::callMacro($name, array $arguments)

Method signature should probably typehint $arguments as array