### PR TITLE
added boolean as return type of findFirst() method

### DIFF
--- a/ide/2.0.8/Phalcon/mvc/Model.php
+++ b/ide/2.0.8/Phalcon/mvc/Model.php
@@ -384,7 +384,7 @@ abstract class Model implements \Phalcon\Mvc\EntityInterface, \Phalcon\Mvc\Model
      * </code>
      *
      * @param string|array $parameters 
-     * @return \Phalcon\Mvc\Model 
+     * @return \Phalcon\Mvc\Model|bool
      */
     public static function findFirst($parameters = null) {}
 


### PR DESCRIPTION
I think, that we can fix it in other version of documentation too. What do you think (I've tested this case only in ` Phalcon 2.0.8`)? 