### PR TITLE
added boolean as return type of findFirst() method

### DIFF
--- a/ide/stubs/Phalcon/mvc/Model.php
+++ b/ide/stubs/Phalcon/mvc/Model.php
@@ -384,7 +384,7 @@ abstract class Model implements \Phalcon\Mvc\EntityInterface, \Phalcon\Mvc\Model
      * </code>
      *
      * @param string|array $parameters 
-     * @return static 
+     * @return static|bool
      */
     public static function findFirst($parameters = null) {}
 


### PR DESCRIPTION
I think, that we can fix it in other version of documentation too (I've tested this case only in Phalcon 2.0.8). As I see, changing `ide/stubs` directory will change other cases too, am I right?