### PR TITLE
Adjusting modelsDir if used from outside of project dir

### DIFF
--- a/scripts/Phalcon/Builder/Model.php
+++ b/scripts/Phalcon/Builder/Model.php
@@ -142,6 +142,11 @@ class Model extends Component
             $modelsDir = $config->get('application')->modelsDir;
         }
 
+        // Adjust modelsDir when called from outside of project dir
+        if ($this->isConsole() && substr($modelsDir, 0, 3) === '../') {
+            $modelsDir = ltrim($modelsDir, './');
+        }
+
         $modelsDir = rtrim($modelsDir, '/\\') . DIRECTORY_SEPARATOR;
         $modelPath = $modelsDir;
         if (false == $this->isAbsolutePath($modelsDir)) {


### PR DESCRIPTION
`php vendor/phalcon/devtools/phalcon.php model posts` caused the following error:
```
PHP Warning:  file_put_contents(/var/www/default/../app/models/Posts.php): failed to open stream: No such file or directory in /var/www/default/vendor/phalcon/devtools/scripts/Phalcon/Builder/Model.php on line 526
PHP Stack trace:
PHP   1. {main}() /var/www/default/vendor/phalcon/devtools/phalcon.php:0
PHP   2. Phalcon\Script->run() /var/www/default/vendor/phalcon/devtools/phalcon.php:86
PHP   3. Phalcon\Script->dispatch() /var/www/default/vendor/phalcon/devtools/scripts/Phalcon/Script.php:150
PHP   4. Phalcon\Commands\Builtin\Model->run() /var/www/default/vendor/phalcon/devtools/scripts/Phalcon/Script.php:125
PHP   5. Phalcon\Builder\Model->build() /var/www/default/vendor/phalcon/devtools/scripts/Phalcon/Commands/Builtin/Model.php:96
PHP   6. file_put_contents() /var/www/default/vendor/phalcon/devtools/scripts/Phalcon/Builder/Model.php:526

  Error: Unable to write to /var/www/default/../app/models/Posts.php
```
In `Phalcon\Build\Controller.php` this is checked correctly.

Signed-off-by: Sebastian Baum <sebastian.baum@ion2s.com>