### PR TITLE
webtools 2.0.x folders patch

### DIFF
--- a/templates/webtools.config.php
+++ b/templates/webtools.config.php
@@ -27,6 +27,7 @@
  *          192.168.0.1 or SUBNET 192., 10.0.2., 86.84.124.
  */
 defined('PTOOLS_IP') || define('PTOOLS_IP', '192.168.');
+defined('APP_PATH') || define('APP_PATH', realpath('..'));
 
 // ---------------------------- DO NOT EDIT BELOW ------------------------------
 


### PR DESCRIPTION
Added APP_PATH constant to webtools config file in order to fix generation via webtools
Without this change, webtools could not detect correct model and controller folders.

In order to reproduce and test:
1. Create a new project WITHOUT ini config:
`phalcon-2.0.x project phalconphp --enable-webtools`
2. Open Controllers tab in webtools
```
Sorry, WebTools doesn't know where the controllers directory is.
Please add the valid path for controllersDir in the application section.
```

Notice: This is also relevant for branch `2.1.x`. However in `2.1.x` there is some other issue related to "scaffold" creation. 

Signed-off-by: Sebastian Baum <sebastian.baum@ion2s.com>