### PR TITLE
[2.0.10] fix PHPDoc into \Phalcon\Mvc\Model.php

### DIFF
--- a/ide/stubs/Phalcon/mvc/Model.php
+++ b/ide/stubs/Phalcon/mvc/Model.php
@@ -605,7 +605,7 @@ abstract class Model implements \Phalcon\Mvc\EntityInterface, \Phalcon\Mvc\Model
      * </code>
      *
      * @param mixed $filter 
-     * @return MessageInterface[] 
+     * @return \Phalcon\Mvc\Model\Message\MessageInterface[] 
      */
     public function getMessages($filter = null) {}
 


### PR DESCRIPTION
there is broken return type as no imports provided and there is no interface in same namespace