### PR TITLE
Set Volt service to shared and change its name from 'voltService' to 'voltShared'

### DIFF
--- a/templates/project/modules/Module_web.php
+++ b/templates/project/modules/Module_web.php
@@ -4,6 +4,7 @@ namespace @@namespace@@\Modules\Frontend;
 use Phalcon\DiInterface;
 use Phalcon\Loader;
 use Phalcon\Mvc\View;
+use Phalcon\Mvc\View\Engine\Php as PhpEngine;
 use Phalcon\Mvc\ModuleDefinitionInterface;
 
 class Module implements ModuleDefinitionInterface
@@ -42,7 +43,7 @@ class Module implements ModuleDefinitionInterface
 
             $view->registerEngines([
                 '.volt'  => 'voltShared',
-                '.phtml' => 'Phalcon\Mvc\View\Engine\Php'
+                '.phtml' => PhpEngine::class
             ]);
 
             return $view;

--- a/templates/project/modules/Module_web.php
+++ b/templates/project/modules/Module_web.php
@@ -41,7 +41,7 @@ class Module implements ModuleDefinitionInterface
             $view->setViewsDir(__DIR__ . '/views/');
 
             $view->registerEngines([
-                '.volt'  => 'voltService',
+                '.volt'  => 'voltShared',
                 '.phtml' => 'Phalcon\Mvc\View\Engine\Php'
             ]);
 

--- a/templates/project/modules/Module_web.php
+++ b/templates/project/modules/Module_web.php
@@ -41,7 +41,8 @@ class Module implements ModuleDefinitionInterface
             $view->setViewsDir(__DIR__ . '/views/');
 
             $view->registerEngines([
-                '.volt'  => 'voltShared'
+                '.volt'  => 'voltShared',
+                '.phtml' => 'Phalcon\Mvc\View\Engine\Php'
             ]);
 
             return $view;

--- a/templates/project/modules/Module_web.php
+++ b/templates/project/modules/Module_web.php
@@ -41,8 +41,7 @@ class Module implements ModuleDefinitionInterface
             $view->setViewsDir(__DIR__ . '/views/');
 
             $view->registerEngines([
-                '.volt'  => 'voltShared',
-                '.phtml' => 'Phalcon\Mvc\View\Engine\Php'
+                '.volt'  => 'voltShared'
             ]);
 
             return $view;

--- a/templates/project/modules/services.php
+++ b/templates/project/modules/services.php
@@ -40,7 +40,7 @@ $di->setShared('modelsMetadata', function () {
 /**
  * Configure the Volt service for rendering .volt templates
  */
-$di->set('voltService', function ($view) {
+$di->setShared('voltShared', function ($view) {
     $config = $this->getConfig();
 
     $volt = new VoltEngine($view, $this);

--- a/templates/project/simple/services.php
+++ b/templates/project/simple/services.php
@@ -1,6 +1,7 @@
 <?php
 
 use Phalcon\Mvc\View;
+use Phalcon\Mvc\View\Engine\Php as PhpEngine;
 use Phalcon\Mvc\Url as UrlResolver;
 use Phalcon\Mvc\View\Engine\Volt as VoltEngine;
 use Phalcon\Mvc\Model\Metadata\Memory as MetaDataAdapter;
@@ -49,7 +50,8 @@ $di->setShared('view', function () {
 
             return $volt;
         },
-        '.phtml' => 'Phalcon\Mvc\View\Engine\Php'
+        '.phtml' => PhpEngine::class
+
     ]);
 
     return $view;


### PR DESCRIPTION
This is merely a convention change that I hope will ease some of the difficulties that people have had with the Volt service not working correctly when normal and simple views are combined.