### PR TITLE
Bug migrations

### DIFF
--- a/scripts/Phalcon/Version/ItemCollection.php
+++ b/scripts/Phalcon/Version/ItemCollection.php
@@ -73,7 +73,7 @@ class ItemCollection
         if (self::TYPE_INCREMENTAL === self::$type) {
             $version = $version ?: '0.0.0';
 
-            return new IncrementalItem($version, $options);
+            return new IncrementalItem($version);
         } elseif (self::TYPE_TIMESTAMPED === self::$type) {
             $version = $version ?: '00000000';
 


### PR DESCRIPTION
Was error:
```
PHP Fatal error:  Out of memory (allocated 1145053184) (tried to allocate 2147483656 bytes) in /vagrant/vendor/phalcon/devtools/scripts/Phalcon/Version/IncrementalItem.php on line 62
PHP Stack trace:
PHP   1. {main}() /vagrant/vendor/phalcon/devtools/phalcon.php:0
PHP   2. Phalcon\Script->run() /vagrant/vendor/phalcon/devtools/phalcon.php:97
PHP   3. Phalcon\Script->dispatch() /vagrant/vendor/phalcon/devtools/scripts/Phalcon/Script.php:150
PHP   4. Phalcon\Commands\Builtin\Migration->run() /vagrant/vendor/phalcon/devtools/scripts/Phalcon/Script.php:125
PHP   5. Phalcon\Migrations::run() /vagrant/vendor/phalcon/devtools/scripts/Phalcon/Commands/Builtin/Migration.php:141
PHP   6. Phalcon\Mvc\Model\Migration::scanForVersions() /vagrant/vendor/phalcon/devtools/scripts/Phalcon/Migrations.php:204
PHP   7. Phalcon\Version\ItemCollection::createItem() /vagrant/vendor/phalcon/devtools/scripts/Phalcon/Mvc/Model/Migration.php:513
PHP   8. Phalcon\Version\IncrementalItem->__construct() /vagrant/vendor/phalcon/devtools/scripts/Phalcon/Version/ItemCollection.php:76

Fatal error: Out of memory (allocated 1145053184) (tried to allocate 2147483656 bytes) in /vagrant/vendor/phalcon/devtools/scripts/Phalcon/Version/IncrementalItem.php on line 62

Call Stack:
    0.0008     362760   1. {main}() /vagrant/vendor/phalcon/devtools/phalcon.php:0
    0.1216     663800   2. Phalcon\Script->run() /vagrant/vendor/phalcon/devtools/phalcon.php:97
    0.1216     663800   3. Phalcon\Script->dispatch() /vagrant/vendor/phalcon/devtools/scripts/Phalcon/Script.php:150
    0.1225     665200   4. Phalcon\Commands\Builtin\Migration->run() /vagrant/vendor/phalcon/devtools/scripts/Phalcon/Script.php:125
    0.1388     764712   5. Phalcon\Migrations::run() /vagrant/vendor/phalcon/devtools/scripts/Phalcon/Commands/Builtin/Migration.php:141
    0.1580     913016   6. Phalcon\Mvc\Model\Migration::scanForVersions() /vagrant/vendor/phalcon/devtools/scripts/Phalcon/Migrations.php:204
    0.1611     921744   7. Phalcon\Version\ItemCollection::createItem() /vagrant/vendor/phalcon/devtools/scripts/Phalcon/Mvc/Model/Migration.php:513
    0.1673     946968   8. Phalcon\Version\IncrementalItem->__construct() /vagrant/vendor/phalcon/devtools/scripts/Phalcon/Version/ItemCollection.php:76


Variables in local scope (#8):
  $i = array ()
  $n = 9
  $nParts = 3
  $numberParts = array ()
  $part = *uninitialized*
  $version = '1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0....'
  $versionStamp = 0
```