### PR TITLE
fix initial migration timestamp based

### DIFF
--- a/scripts/Phalcon/Version/ItemCollection.php
+++ b/scripts/Phalcon/Version/ItemCollection.php
@@ -75,7 +75,7 @@ class ItemCollection
 
             return new IncrementalItem($version);
         } elseif (self::TYPE_TIMESTAMPED === self::$type) {
-            $version = $version ?: '000';
+            $version = $version ?: '0000000_0';
 
             return new TimestampedItem($version, $options);
         }


### PR DESCRIPTION
fix #750 - this fixes the problem when migration is timestampbased - default value is not according to REGEX requirement