### PR TITLE
Fixed possible problems with PostgreSQL-Connections in generated code

### DIFF
--- a/templates/project/cli/services.php
+++ b/templates/project/cli/services.php
@@ -14,13 +14,20 @@ $di->setShared('db', function () {
     $config = $this->getConfig();
 
     $class = 'Phalcon\Db\Adapter\Pdo\\' . $config->database->adapter;
-    $connection = new $class([
+
+    $params = [
         'host'     => $config->database->host,
         'username' => $config->database->username,
         'password' => $config->database->password,
         'dbname'   => $config->database->dbname,
         'charset'  => $config->database->charset
-    ]);
+    ];
+
+    if ($config->database->adapter == 'Postgresql') {
+        unset($params['charset']);
+    }
+
+    $connection = new $class($params);
 
     return $connection;
 });

--- a/templates/project/micro/services.php
+++ b/templates/project/micro/services.php
@@ -39,13 +39,19 @@ $di->setShared('db', function () {
     $config = $this->getConfig();
 
     $class = 'Phalcon\Db\Adapter\Pdo\\' . $config->database->adapter;
-    $connection = new $class([
+    $params = [
         'host'     => $config->database->host,
         'username' => $config->database->username,
         'password' => $config->database->password,
         'dbname'   => $config->database->dbname,
         'charset'  => $config->database->charset
-    ]);
+    ];
+
+    if ($config->database->adapter == 'Postgresql') {
+        unset($params['charset']);
+    }
+
+    $connection = new $class($params);
 
     return $connection;
 });

--- a/templates/project/modules/services.php
+++ b/templates/project/modules/services.php
@@ -19,13 +19,19 @@ $di->setShared('db', function () {
     $config = $this->getConfig();
 
     $class = 'Phalcon\Db\Adapter\Pdo\\' . $config->database->adapter;
-    $connection = new $class([
+    $params = [
         'host'     => $config->database->host,
         'username' => $config->database->username,
         'password' => $config->database->password,
         'dbname'   => $config->database->dbname,
         'charset'  => $config->database->charset
-    ]);
+    ];
+
+    if ($config->database->adapter == 'Postgresql') {
+        unset($params['charset']);
+    }
+
+    $connection = new $class($params);
 
     return $connection;
 });

--- a/templates/project/simple/services.php
+++ b/templates/project/simple/services.php
@@ -64,13 +64,19 @@ $di->setShared('db', function () {
     $config = $this->getConfig();
 
     $class = 'Phalcon\Db\Adapter\Pdo\\' . $config->database->adapter;
-    $connection = new $class([
+    $params = [
         'host'     => $config->database->host,
         'username' => $config->database->username,
         'password' => $config->database->password,
         'dbname'   => $config->database->dbname,
         'charset'  => $config->database->charset
-    ]);
+    ];
+
+    if ($config->database->adapter == 'Postgresql') {
+        unset($params['charset']);
+    }
+
+    $connection = new $class($params);
 
     return $connection;
 });


### PR DESCRIPTION
charset is not a parameter for PostgreSQL Connections and thus switching to PostgreSQL inside an automatically generated project throws exceptions whenever something a database connection is attempted.

this proposed change keeps it more flexible by unsetting the key 'charset' from the adapters config array if the adapter is PostgreSQL