### PR TITLE
Adding attribution

### DIFF
--- a/scripts/Phalcon/Builder/Project/Modules.php
+++ b/scripts/Phalcon/Builder/Project/Modules.php
@@ -15,6 +15,7 @@
   +------------------------------------------------------------------------+
   | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
   |          Eduar Carvajal <eduar@phalconphp.com>                         |
+  |          David Schissler <david.schissler@gmail.com>                   |
   |          Serghei Iakovlev <serghei@phalconphp.com>                     |
   +------------------------------------------------------------------------+
 */


### PR DESCRIPTION
I was going through my commit history and I noticed that I was using Eduar's email from a copy-paste error.  So then I went to fix that and then I noticed that my entry had been removed.  So now I am adding it back with the correct email.