### PR TITLE
Problem if u have db name == schema name

### DIFF
--- a/scripts/Phalcon/Builder/Model.php
+++ b/scripts/Phalcon/Builder/Model.php
@@ -220,7 +220,7 @@ class Model extends Component
             $schema = Utils::resolveDbSchema($config->database);
         }
 
-        if ($schema && $schema != $config->database->dbname) {
+        if ($schema) {
             $initialize['schema'] = $this->snippet->getThisMethod('setSchema', $schema);
         }
 


### PR DESCRIPTION
I use postgres. My db name is "test" and my schema name is "test".
If I build the models, with the script, it creates them correctly, but I receive this error when I try to use a table: "Table 'table' doesn't exist in database when dumping meta-data for Table".

After trying to figure out where the problem was, I realized that into the initialization method of the model, the method "setSchema" was not called. 
Why when I set the schema (phalcon model --schema=test ...) with dev-tools, this checks if the schema name is the same as the database name ($schema != $config->database->dbname)?