### PR TITLE
#897 - fixed duplicate columns in Migration

### DIFF
--- a/scripts/Phalcon/Mvc/Model/Migration.php
+++ b/scripts/Phalcon/Mvc/Model/Migration.php
@@ -338,8 +338,8 @@ class Migration
             $referenceDefinition = [];
             $referenceDefinition[] = "'referencedSchema' => '".$dbReference->getReferencedSchema()."'";
             $referenceDefinition[] = "'referencedTable' => '".$dbReference->getReferencedTable()."'";
-            $referenceDefinition[] = "'columns' => [".join(",", $columns)."]";
-            $referenceDefinition[] = "'referencedColumns' => [".join(",", $referencedColumns)."]";
+            $referenceDefinition[] = "'columns' => [".join(",", array_unique($columns))."]";
+            $referenceDefinition[] = "'referencedColumns' => [".join(",", array_unique($referencedColumns))."]";
             $referenceDefinition[] = "'onUpdate' => '".$dbReference->getOnUpdate()."'";
             $referenceDefinition[] = "'onDelete' => '".$dbReference->getOnDelete()."'";
 


### PR DESCRIPTION
Fixed error 897 - from fork https://github.com/Arrim/phalcon-devtools/commit/353d07dee84a1835b38d8697cb0a5c4387a429c2
Added array_unique to avoid duplicate columns