### PR TITLE
Allow 'simple' project template 'url' service to understand non-root project paths.

### DIFF
--- a/templates/project/simple/config.php
+++ b/templates/project/simple/config.php
@@ -24,6 +24,10 @@ return new \Phalcon\Config([
         'pluginsDir'     => APP_PATH . '/plugins/',
         'libraryDir'     => APP_PATH . '/library/',
         'cacheDir'       => BASE_PATH . '/cache/',
+
+        // This allows the baseUri to be understand project paths that are not in the root directory
+        // of the webpspace.  This will break if the public/index.php entry point is moved or
+        // possibly if the web server rewrite rules are changed. This can also be set to a static path.
         'baseUri'        => preg_replace('/public([\/\\\\])index.php$/', '', $_SERVER["PHP_SELF"]),
     ]
 ]);

--- a/templates/project/simple/config.php
+++ b/templates/project/simple/config.php
@@ -24,6 +24,6 @@ return new \Phalcon\Config([
         'pluginsDir'     => APP_PATH . '/plugins/',
         'libraryDir'     => APP_PATH . '/library/',
         'cacheDir'       => BASE_PATH . '/cache/',
-        'baseUri'        => '/@@name@@/',
+        'baseUri'        => preg_replace('/public([\/\\\\])index.php$/', '', $_SERVER["PHP_SELF"]),
     ]
 ]);


### PR DESCRIPTION
The issue is that dev tools templates only understand being in the root directory of a web space or vhost and this is never the case in my projects.  One downside of this pull request is that now the ini config doesn't match the normal one but I don't see how this can be done with an ini file.  Its still no worse for ini then it was so it will just be a different flavor.

* This should handle Windows and Unix path separators.
* This only changes the `simple` template and later I will add the `modules` fix as well (but I'm having much more serious issues with `modules` at the moment).