### PR TITLE
Fixes and cleanups for 'modules' project

### DIFF
--- a/templates/project/modules/config.php
+++ b/templates/project/modules/config.php
@@ -23,7 +23,11 @@ return new \Phalcon\Config([
         'modelsDir'      => APP_PATH . '/common/models/',
         'migrationsDir'  => APP_PATH . '/migrations/',
         'cacheDir'       => BASE_PATH . '/cache/',
-        'baseUri'        => '/@@name@@/'
+
+        // This allows the baseUri to be understand project paths that are not in the root directory
+        // of the webpspace.  This will break if the public/index.php entry point is moved or
+        // possibly if the web server rewrite rules are changed. This can also be set to a static path.
+        'baseUri'        => preg_replace('/public([\/\\\\])index.php$/', '', $_SERVER["PHP_SELF"]),
     ],
 
     /**

--- a/templates/project/modules/routes.php
+++ b/templates/project/modules/routes.php
@@ -1,9 +1,9 @@
 <?php
 
-$router = $di->get("router");
+$router = $di->getRouter();
 
 foreach ($application->getModules() as $key => $module) {
-    $namespace = str_replace('Module','Controllers', $module["className"]);
+    $namespace = preg_replace('/Module$/', 'Controllers', $module["className"]);
     $router->add('/'.$key.'/:params', [
         'namespace' => $namespace,
         'module' => $key,
@@ -26,5 +26,3 @@ foreach ($application->getModules() as $key => $module) {
         'params' => 3
     ]);
 }
-
-$di->set("router", $router);

--- a/templates/project/modules/services_web.php
+++ b/templates/project/modules/services_web.php
@@ -15,7 +15,6 @@ $di->setShared('router', function () {
     $router = new Router();
 
     $router->setDefaultModule('frontend');
-    $router->setDefaultNamespace('@@namespace@@\Modules\Frontend\Controllers');
 
     return $router;
 });


### PR DESCRIPTION
I added the 'url' fix fom 'simple' project.

Another issue was was due to some of the `modules` code being copied from `simple` where `Module` was being replaced with `Controllers`.  I changed it to match to the end of the string because the module classes have two "Module" strings in them, once for "Modules" and then another time at the end for the class name itself.

I tested a dispatcher forward as well as the following paths and they all work:

* /projects_container/test_modules/
* /projects_container/test_modules/index
* /projects_container/test_modules/index/index
* /projects_container/test_modules/frontend
* /projects_container/test_modules/frontend/index
* /projects_container/test_modules/frontend/index/index
* /projects_container/test_modules/frontend/test
* /projects_container/test_modules/frontend/test/other