### PR TITLE
Solution for github issue #906 "Modules Template for Routers"

### DIFF
--- a/templates/project/modules/routes.php
+++ b/templates/project/modules/routes.php
@@ -3,7 +3,7 @@
 $router = $di->get("router");
 
 foreach ($application->getModules() as $key => $module) {
-    $namespace = str_replace('Module','Controllers', $module["className"]);
+    $namespace = preg_replace('/\bModule\b/', 'Controllers', $module["className"]);
     $router->add('/'.$key.'/:params', [
         'namespace' => $namespace,
         'module' => $key,


### PR DESCRIPTION
Creating a modules application you may notice that automatic route loop produces wrong namespace, since it replaces both 'Module' and 'Modules' with 'Controller' string. As a result routers are useless since they not match to actual namespaces.

Signed-off-by: Georgios Tsotsos <tsotsos@gmail.com>