### PR TITLE
Incorrect current version in case multiple versions in migration file

### DIFF
--- a/scripts/Phalcon/Migrations.php
+++ b/scripts/Phalcon/Migrations.php
@@ -482,6 +482,9 @@ class Migrations
                 : null;
             $version = trim($version) ?: null;
 
+            $versions = explode("\n", str_replace(array("\r\n", "\r"), "\n", $version));
+            $version  = end($versions);
+
             return VersionCollection::createItem($version);
         }
     }


### PR DESCRIPTION
**Problem**
In case migrations is stored in a file, right now they're stored in following format:
1.0.0
1.0.1
...

Current implementation of '_getCurrentVersion()_' takes whole content of that file and wrap it in **VersionItem** class, which leads to wrong comparsion.

I hope this example will explain this better:
Migration file has this in it:
1.0.0
1.0.1

Available migrations:
1.0.0
1.0.1
1.0.2

So we want to apply latest missing migration, 1.0.2. We expect that '_getCurrentVersion()_' will return version 1.0.1 (because migration file says so), but it returns **VersionItem** class with this as version (without quotes):
"1.0.0
1.0.1"
which is incorrect and when i try to apply 1.0.2 migration, it causes "Version 1.0.2 was already rolled back", which is completely wrong (because it should apply new migration, not rollback).

My fix explodes the whole migration file by newline (normalizing them first to \n) and takes latest entry. It will work even if migration file has one version in it. Now if i run it, script will output this:
Version 1.0.0 was already applied
Version 1.0.1 was already applied
-- Version 1.0.2 SQLs --

Hope it helps and sorry for a lot of text! :)