### PR TITLE
Use csv for data export

### DIFF
--- a/phalcon.sh
+++ b/phalcon.sh
@@ -133,7 +133,7 @@ check_install(){
 	else
 		devtools=${PTOOLSPATH%/}
 		if [ "${devtools}" != "${DIR}" ]; then
-			printf "\n${PURPLE}The You environment variable \$PTOOLSPATH is outdated!${NC}"
+			printf "\n${PURPLE}Your environment variable \$PTOOLSPATH is outdated!${NC}"
 			printf "\n${PURPLE}Current value: $devtools${NC}"
 			printf "\n${PURPLE}New value: $DIR${NC}"
 			printf "\nExit.\n\n"

--- a/scripts/Phalcon/Mvc/Model/Migration.php
+++ b/scripts/Phalcon/Mvc/Model/Migration.php
@@ -412,13 +412,13 @@ class Migration
                             $data[] = addslashes($value);
                         }
                     } else {
-                        $data[] = "'".addslashes($value)."'";
+                        $data[] = is_null($value) ? "NULL" : addslashes($value);
                     }
 
                     unset($value);
                 }
 
-                fputs($fileHandler, join('|', $data).PHP_EOL);
+                fputcsv($fileHandler, $data);
                 unset($row);
                 unset($data);
             }
@@ -829,12 +829,12 @@ class Migration
         self::$_connection->begin();
         self::$_connection->delete($tableName);
         $batchHandler = fopen($migrationData, 'r');
-        while (($line = fgets($batchHandler)) !== false) {
+        while (($line = fgetcsv($batchHandler)) !== false) {
             $values = array_map(
                 function ($value) {
-                    return '' === $value || null === $value ? null : trim($value, "'");
+                    return null === $value ? null : $value;
                 },
-                explode('|', rtrim($line))
+                $line
             );
 
             self::$_connection->insert($tableName, $values, $fields);

--- a/scripts/Phalcon/Version/VersionAwareTrait.php
+++ b/scripts/Phalcon/Version/VersionAwareTrait.php
@@ -38,7 +38,7 @@ trait VersionAwareTrait
      */
     public function getVersion()
     {
-        return $this->_version;
+        return $this->version;
     }
 
     /**


### PR DESCRIPTION
This is just a suggestion, but I ran into some very annoying issues trying to import a large dataset with newlines inside text and memo fields. There are also some typo fixes (one in a comment and another in Phalcon\Version\VersionAwareTrait that was breaking migrations)