### PR TITLE
Seek for custom autoloader relatively from dir. where DevTools was invoked

### DIFF
--- a/bootstrap/autoload.php
+++ b/bootstrap/autoload.php
@@ -37,7 +37,7 @@ defined('DEVTOOLS_START_TIME') || define('DEVTOOLS_START_TIME', microtime(true))
 /**
  * @const DEVTOOLS_START_MEMORY The memory usage at the start of the application. Used for profiling.
  */
-defined('DEVTOOLS_START_TIME') || define('DEVTOOLS_START_MEMORY', memory_get_usage());
+defined('DEVTOOLS_START_MEMORY') || define('DEVTOOLS_START_MEMORY', memory_get_usage());
 
 /**
  * @const PTOOLSPATH The path to the Phalcon Developers Tools.
@@ -127,8 +127,8 @@ if (file_exists(PTOOLSPATH . DS .'vendor' . DS . 'autoload.php')) {
 /**
  * Register the custom loader (if any)
  */
-if (file_exists(PTOOLSPATH . DS . '.phalcon' . DS . 'autoload.php')) {
-    require_once PTOOLSPATH . DS .  '.phalcon' . DS . 'autoload.php';
+if (file_exists('.phalcon' . DS . 'autoload.php')) {
+    require_once '.phalcon' . DS . 'autoload.php';
 }
 
 if (Version::getId() < COMPATIBLE_VERSION) {


### PR DESCRIPTION
Realted to #778

Type: bug fix

This pull request affects the following components: **(please check boxes)**

- [x] Bootstrap
- [ ] Core
- [ ] WebTools
- [ ] Migrations
- [ ] Models
- [ ] Scaffold
- [ ] Documentation
- [ ] IDE
- [ ] MySQL
- [ ] PostgreSQL
- [ ] Oracle
- [ ] SQLite
- [ ] Testing
- [ ] Code Quality
- [ ] Templating

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

- Seek for custom autoloader change, from PTOOLSPATH to cwd.
- Typo fix

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md