### PR TITLE
fix db referencing problem

### DIFF
--- a/scripts/Phalcon/Mvc/Model/Migration.php
+++ b/scripts/Phalcon/Mvc/Model/Migration.php
@@ -332,7 +332,6 @@ class Migration
             }
 
             $referenceDefinition = [];
-            $referenceDefinition[] = "'referencedSchema' => '".$dbReference->getReferencedSchema()."'";
             $referenceDefinition[] = "'referencedTable' => '".$dbReference->getReferencedTable()."'";
             $referenceDefinition[] = "'columns' => [".join(",", array_unique($columns))."]";
             $referenceDefinition[] = "'referencedColumns' => [".join(",", array_unique($referencedColumns))."]";


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/phalcon-devtools/issues/238

This pull request affects the following components: **(please check boxes)**

- [ ] Core
- [ ] WebTools
- [x] Migrations
- [ ] Models
- [ ] Scaffold
- [ ] Documentation
- [ ] IDE
- [ ] MySQL
- [ ] PostgreSQL
- [ ] Oracle
- [ ] SQLite
- [ ] Testing
- [ ] Code Quality
- [ ] Templating

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

This bug occurs when the development db name is different from the production db name. When the migration tool generates the migration script from the development environment, the references contains the development db name (referencedSchema). When doing the migration in production server, the migration tool still reads referencedSchema even the db config is set to production because the db name in referencedSchema is hardcoded within the script. By removing referencedSchema from generating the migration script will fix this problem. Since this migration tool does not support multiple db schemas currently, db name should be default to the config db name instead of reading from the script.


Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
