### PR TITLE
Fixed box.json bootstrap directory issue. PHAR should now run correct…

### DIFF
--- a/box.json
+++ b/box.json
@@ -3,6 +3,7 @@
   "output": "phalcon.phar",
   "chmod": "0755",
   "directories": [
+    "bootstrap",
     "resources",
     "scripts",
     "templates"


### PR DESCRIPTION
* Type: bug fix
* Link to issue: https://github.com/phalcon/phalcon-devtools/issues/943

This pull request affects the following components: **(please check boxes)**

- [x] Core
- [ ] WebTools
- [ ] Migrations
- [ ] Models
- [ ] Scaffold
- [ ] Documentation
- [ ] IDE
- [ ] MySQL
- [ ] PostgreSQL
- [ ] Oracle
- [ ] SQLite
- [ ] Testing
- [ ] Code Quality
- [ ] Templating

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:
Just added "bootstrap" in the box.json directories so the autoload.php file is included in the generated .phar as well (tested).

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
