### PR TITLE
Fixed Phalcon\Mvc\Model::find return type name (error in namespace)

### DIFF
--- a/ide/stubs/Phalcon/mvc/Model.php
+++ b/ide/stubs/Phalcon/mvc/Model.php
@@ -430,7 +430,7 @@ abstract class Model implements \Phalcon\Mvc\EntityInterface, \Phalcon\Mvc\Model
      * </code>
      *
      * @param mixed $parameters
-     * @return ResultsetInterface
+     * @return Model\ResultsetInterface
      */
     public static function find($parameters = null) {}
 


### PR DESCRIPTION
Hello!

* Type: bug fix 

This pull request affects the following components:

- [ ] Core
- [ ] WebTools
- [ ] Migrations
- [ ] Models
- [ ] Scaffold
- [ ] Documentation
- [x] IDE
- [ ] MySQL
- [ ] PostgreSQL
- [ ] Oracle
- [ ] SQLite
- [ ] Testing
- [ ] Code Quality
- [ ] Templating

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

In IDE stubs `Phalcon\Mvc\Model::find` method`s return type was written as `ResultsetInterface`. Namespace of file with this stub is `Phalcon\Mvc`. So IDE was thinking that `find` method should return an object with type `Phalcon\Mvc\ResultsetInterface`. But in fact class with this name is not found in framework. So I added `Model` before `ResultsetInterface` for fixing this bug.

You can see more information on screenshots:

![2017-01-20 21 54 49](https://cloud.githubusercontent.com/assets/5189110/22161619/4e8fc4e8-df5c-11e6-94ef-fbccf77d165e.png)
![2017-01-20 21 55 00](https://cloud.githubusercontent.com/assets/5189110/22161618/4e8d37dc-df5c-11e6-87fb-61797e703567.png)



Thanks


