### PR TITLE
IDE Stubs - Update Phalcon\Mvc\Model -> getRelated function @return type

### DIFF
--- a/ide/stubs/Phalcon/mvc/Model.php
+++ b/ide/stubs/Phalcon/mvc/Model.php
@@ -491,7 +491,7 @@ abstract class Model implements \Phalcon\Mvc\EntityInterface, \Phalcon\Mvc\Model
      * @param string $alias
      * @param array $parameters
      * @param string $function
-     * @return ResultsetInterface
+     * @return Model\ResultsetInterface
      */
     protected static function _groupResult($functionName, $alias, $parameters) {}
 
@@ -1322,7 +1322,7 @@ abstract class Model implements \Phalcon\Mvc\EntityInterface, \Phalcon\Mvc\Model
      *
      * @param string $alias
      * @param array $arguments
-     * @return ResultsetInterface
+     * @return Model\ResultsetInterface
      */
     public function getRelated($alias, $arguments = null) {}
 


### PR DESCRIPTION
ResultsetInterface was returned, but namespace was not specified. It was trying to load "\Phalcon\Mvc\ResultsetInterface" and not "\Phalcon\Mvc\Model\ResultsetInterface"

I'll update it in the official Phalcon repository so it can be generated correctly next time.

Hello!

* Type: bug fix 

This pull request affects the following components: **(please check boxes)**

- [ ] Core
- [ ] WebTools
- [ ] Migrations
- [ ] Models
- [ ] Scaffold
- [ ] Documentation
- [x] IDE
- [ ] MySQL
- [ ] PostgreSQL
- [ ] Oracle
- [ ] SQLite
- [ ] Testing
- [ ] Code Quality
- [ ] Templating

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
