### PR TITLE
Code Quality Migration::$_storage to protected

### DIFF
--- a/scripts/Phalcon/Migrations.php
+++ b/scripts/Phalcon/Migrations.php
@@ -51,7 +51,7 @@ class Migrations
      * Filename or db connection to store migrations log
      * @var mixed|Adapter\Pdo
      */
-    private static $_storage;
+    protected static $_storage;
 
     /**
      * Check if the script is running on Console mode


### PR DESCRIPTION
This change will make possible for classes that extend Migrations to be able to with $_storage variable

this is useful in my case for modular setup each one with it's own migration and path with version.

Hello!

* Type: bug fix | new feature | code quality | documentation
* Link to issue:

This pull request affects the following components: **(please check boxes)**

- [ ] Core
- [ ] WebTools
- [x] Migrations
- [ ] Models
- [ ] Scaffold
- [ ] Documentation
- [ ] IDE
- [ ] MySQL
- [ ] PostgreSQL
- [ ] Oracle
- [ ] SQLite
- [ ] Testing
- [x] Code Quality
- [ ] Templating

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
