### PR TITLE
Update getSqlVariables return type

### DIFF
--- a/ide/stubs/Phalcon/db/Adapter.php
+++ b/ide/stubs/Phalcon/db/Adapter.php
@@ -93,7 +93,7 @@ abstract class Adapter implements \Phalcon\Db\AdapterInterface, \Phalcon\Events\
     /**
      * Active SQL bound parameter variables
      *
-     * @return string
+     * @return array
      */
     public function getSqlVariables() {}
 


### PR DESCRIPTION
Change return type for getSqlVariables to array (from string).

Hello!

* Type: code quality

This pull request affects the following components: **(please check boxes)**

- [ ] Core
- [ ] WebTools
- [ ] Migrations
- [ ] Models
- [ ] Scaffold
- [ ] Documentation
- [ ] IDE
- [ ] MySQL
- [ ] PostgreSQL
- [ ] Oracle
- [ ] SQLite
- [ ] Testing
- [*] Code Quality
- [ ] Templating

**In raising this pull request, I confirm the following (please check boxes):**

- [*] I have read and understood the [Contributing Guidelines][:contrib:]?
- [*] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:
Return type was not correct. I've changed it to array for getSqlVariables

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
