### PR TITLE
Added parameters loading from additional devtools config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,26 @@ $config = [
 ];
 ```
 
+## Configuration file
+
+By creating **phalcon.json** or any other configuration file called **phalcon** in root project you can set options for all possible commands, for example:
+
+```json
+{
+  "migration" : {
+    "migrations": "App/Migrations",
+    "config": "App/Config/db.ini"
+  },
+  "controller" : {
+    "namespace": "Phalcon\\Test",
+    "directory": "App/Controllers",
+    "base-class": "App\\MyAbstractController"
+  }
+}
+```
+
+And then you can use use `phalcon migration run` or `phalcon controller SomeClass` and those commands will be executed with options from file. Arguments provided by developer from command line will overwrite existing one in file.
+
 ## License
 
 Phalcon Developer Tools is open source software licensed under the [New BSD License][:license:].<br>

--- a/scripts/Phalcon/Commands/Command.php
+++ b/scripts/Phalcon/Commands/Command.php
@@ -301,6 +301,18 @@ abstract class Command implements CommandsInterface
             }
         }
 
+        foreach (['ini', 'php', 'json', 'yaml'] as $extension) {
+            if (file_exists("phalcon.".$extension)) {
+                $config = $this->loadConfig("phalcon.".$extension);
+                $commandName = $this->getCommands()[0];
+                $optionsToMerge = $config->get($commandName);
+                if (!empty($optionsToMerge)) {
+                    $receivedParams = array_merge($optionsToMerge->toArray(), $receivedParams);
+                }
+                break;
+            }
+        }
+
         $this->_parameters = $receivedParams;
 
         return $receivedParams;


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: https://github.com/phalcon/phalcon-devtools/issues/980

This pull request affects the following components: **(please check boxes)**

- [x] Core
- [ ] WebTools
- [x] Migrations
- [x] Models
- [x] Scaffold
- [ ] Documentation
- [ ] IDE
- [ ] MySQL
- [ ] PostgreSQL
- [ ] Oracle
- [ ] SQLite
- [ ] Testing
- [ ] Code Quality
- [ ] Templating

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: This is adding way to load options for commands from `phalcon.json`(or any other extension) file in root project category.

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
