### PR TITLE
Add module-directories and namespace-alias parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ env:
     - CC="ccache gcc"
     - PATH="$PATH:~/bin"
     - DISPLAY=":99.0"
-    - PHALCON_VERSION="v3.0.2"
+    - PHALCON_VERSION="v3.0.4"
 
 script:
   - tests/lint.sh --lint ${TRAVIS_BUILD_DIR}/ide/stubs

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Create the composer.json file as follows:
 ```json
 {
     "require-dev": {
-        "phalcon/devtools": "~3.0.3"
+        "phalcon/devtools": "~3.0"
     }
 }
 ```
@@ -113,7 +113,7 @@ This command should display something similar to:
 ```sh
 $ phalcon --help
 
-Phalcon DevTools (3.0.2)
+Phalcon DevTools (3.0.4)
 
 Help:
   Lists the commands available in Phalcon devtools

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     },
     "require": {
         "php": ">=5.5",
-        "ext-phalcon": "^3.0"
+        "ext-phalcon": "^3.0",
+        "psy/psysh": "@stable"
     },
     "require-dev": {
         "kherge/box": "^2.7"

--- a/ide/stubs/Phalcon/Dispatcher.php
+++ b/ide/stubs/Phalcon/Dispatcher.php
@@ -92,6 +92,9 @@ abstract class Dispatcher implements \Phalcon\DispatcherInterface, \Phalcon\Di\I
     protected $_modelBinding = false;
 
 
+    protected $_modelBinder = null;
+
+
     /**
      * Sets the dependency injector
      *
@@ -268,9 +271,47 @@ abstract class Dispatcher implements \Phalcon\DispatcherInterface, \Phalcon\Di\I
     /**
      * Enable/Disable model binding during dispatch
      *
-     * @param boolean $value
+     * <code>
+     * $di->set('dispatcher', function() {
+     *     $dispatcher = new Dispatcher();
+     *
+     *     $dispatcher->setModelBinding(true, 'cache');
+     *     return $dispatcher;
+     * });
+     * </code>
+     *
+     * @deprecated 3.1.0 Use setModelBinder method
+     * @see Phalcon\Dispatcher::setModelBinder()
+     * @param bool $value
+     * @param mixed $cache
+     * @return Dispatcher
      */
-    public function setModelBinding($value) {}
+    public function setModelBinding($value, $cache = null) {}
+
+    /**
+     * Enable model binding during dispatch
+     *
+     * <code>
+     * $di->set('dispatcher', function() {
+     *     $dispatcher = new Dispatcher();
+     *
+     *     $dispatcher->setModelBinder(new Binder(), 'cache');
+     *     return $dispatcher;
+     * });
+     * </code>
+     *
+     * @param \Phalcon\Mvc\Model\BinderInterface $modelBinder
+     * @param mixed $cache
+     * @return Dispatcher
+     */
+    public function setModelBinder(\Phalcon\Mvc\Model\BinderInterface $modelBinder, $cache = null) {}
+
+    /**
+     * Gets model binder
+     *
+     * @return null|\Phalcon\Mvc\Model\BinderInterface
+     */
+    public function getModelBinder() {}
 
     /**
      * Dispatches a handle action taking into account the routing parameters
@@ -323,6 +364,23 @@ abstract class Dispatcher implements \Phalcon\DispatcherInterface, \Phalcon\Di\I
      * @param array $params
      */
     public function callActionMethod($handler, $actionMethod, array $params = array()) {}
+
+    /**
+     * Returns bound models from binder instance
+     *
+     * <code>
+     * class UserController extends Controller
+     * {
+     *     public function showAction(User $user)
+     *     {
+     *         $boundModels = $this->dispatcher->getBoundModels(); // return array with $user
+     *     }
+     * }
+     * </code>
+     *
+     * @return array
+     */
+    public function getBoundModels() {}
 
     /**
      * Set empty properties to their defaults (where defaults are available)

--- a/ide/stubs/Phalcon/Loader.php
+++ b/ide/stubs/Phalcon/Loader.php
@@ -162,9 +162,10 @@ class Loader implements \Phalcon\Events\EventsAwareInterface
     /**
      * Register the autoload method
      *
+     * @param bool $prepend
      * @return Loader
      */
-    public function register() {}
+    public function register($prepend = null) {}
 
     /**
      * Unregister the autoload method

--- a/ide/stubs/Phalcon/Tag.php
+++ b/ide/stubs/Phalcon/Tag.php
@@ -676,14 +676,14 @@ class Tag
     /**
      * Appends a text to current document title
      *
-     * @param string $title
+     * @param mixed $title
      */
     public static function appendTitle($title) {}
 
     /**
      * Prepends a text to current document title
      *
-     * @param string $title
+     * @param mixed $title
      */
     public static function prependTitle($title) {}
 

--- a/ide/stubs/Phalcon/Validation.php
+++ b/ide/stubs/Phalcon/Validation.php
@@ -37,6 +37,9 @@ class Validation extends \Phalcon\Di\Injectable implements \Phalcon\ValidationIn
     protected $_values;
 
 
+
+    public function getData() {}
+
     /**
      * @param mixed $validators
      */

--- a/ide/stubs/Phalcon/db/Adapter.php
+++ b/ide/stubs/Phalcon/db/Adapter.php
@@ -93,7 +93,7 @@ abstract class Adapter implements \Phalcon\Db\AdapterInterface, \Phalcon\Events\
     /**
      * Active SQL bound parameter variables
      *
-     * @return string
+     * @return array
      */
     public function getSqlVariables() {}
 

--- a/ide/stubs/Phalcon/db/Index.php
+++ b/ide/stubs/Phalcon/db/Index.php
@@ -8,6 +8,30 @@ namespace Phalcon\Db;
  * Allows to define indexes to be used on tables. Indexes are a common way
  * to enhance database performance. An index allows the database server to find
  * and retrieve specific rows much faster than it could do without an index
+ *
+ * <code>
+ * // Define new unique index
+ * $index_unique = new \Phalcon\Db\Index(
+ *     'column_UNIQUE',
+ *     [
+ *         'column',
+ *         'column'
+ *     ],
+ *     'UNIQUE'
+ * );
+ *
+ * // Define new primary index
+ * $index_primary = new \Phalcon\Db\Index(
+ *     'PRIMARY',
+ *     [
+ *         'column'
+ *     ]
+ * );
+ *
+ * // Add index to existing table
+ * $connection->addIndex("robots", null, $index_unique);
+ * $connection->addIndex("robots", null, $index_primary);
+ * </code>
  */
 class Index implements \Phalcon\Db\IndexInterface
 {

--- a/ide/stubs/Phalcon/db/dialect/Mysql.php
+++ b/ide/stubs/Phalcon/db/dialect/Mysql.php
@@ -122,6 +122,15 @@ class Mysql extends \Phalcon\Db\Dialect
     public function createTable($tableName, $schemaName, array $definition) {}
 
     /**
+     * Generates SQL to truncate a table
+     *
+     * @param string $tableName
+     * @param string $schemaName
+     * @return string
+     */
+    public function truncateTable($tableName, $schemaName) {}
+
+    /**
      * Generates SQL to drop a table
      *
      * @param string $tableName

--- a/ide/stubs/Phalcon/db/dialect/Postgresql.php
+++ b/ide/stubs/Phalcon/db/dialect/Postgresql.php
@@ -122,6 +122,15 @@ class Postgresql extends \Phalcon\Db\Dialect
     public function createTable($tableName, $schemaName, array $definition) {}
 
     /**
+     * Generates SQL to truncate a table
+     *
+     * @param string $tableName
+     * @param string $schemaName
+     * @return string
+     */
+    public function truncateTable($tableName, $schemaName) {}
+
+    /**
      * Generates SQL to drop a table
      *
      * @param string $tableName

--- a/ide/stubs/Phalcon/db/dialect/Sqlite.php
+++ b/ide/stubs/Phalcon/db/dialect/Sqlite.php
@@ -122,6 +122,15 @@ class Sqlite extends \Phalcon\Db\Dialect
     public function createTable($tableName, $schemaName, array $definition) {}
 
     /**
+     * Generates SQL to truncate a table
+     *
+     * @param string $tableName
+     * @param string $schemaName
+     * @return string
+     */
+    public function truncateTable($tableName, $schemaName) {}
+
+    /**
      * Generates SQL to drop a table
      *
      * @param string $tableName

--- a/ide/stubs/Phalcon/mvc/Collection.php
+++ b/ide/stubs/Phalcon/mvc/Collection.php
@@ -23,6 +23,15 @@ abstract class Collection implements \Phalcon\Mvc\EntityInterface, \Phalcon\Mvc\
     const OP_DELETE = 3;
 
 
+    const DIRTY_STATE_PERSISTENT = 0;
+
+
+    const DIRTY_STATE_TRANSIENT = 1;
+
+
+    const DIRTY_STATE_DETACHED = 2;
+
+
     public $_id;
 
 
@@ -36,6 +45,9 @@ abstract class Collection implements \Phalcon\Mvc\EntityInterface, \Phalcon\Mvc\
 
 
     protected $_operationMade = 0;
+
+
+    protected $_dirtyState = 1;
 
 
     protected $_connection;
@@ -245,6 +257,7 @@ abstract class Collection implements \Phalcon\Mvc\EntityInterface, \Phalcon\Mvc\
      * {
      *     public function validation()
      *     {
+     *         // Old, deprecated syntax, use new one below
      *         $this->validate(
      *             new ExclusionIn(
      *                 [
@@ -261,9 +274,31 @@ abstract class Collection implements \Phalcon\Mvc\EntityInterface, \Phalcon\Mvc\
      * }
      * </code>
      *
-     * @param Model\ValidatorInterface $validator
+     * <code>
+     * use Phalcon\Validation\Validator\ExclusionIn as ExclusionIn;
+     * use Phalcon\Validation;
+     *
+     * class Subscriptors extends \Phalcon\Mvc\Collection
+     * {
+     *     public function validation()
+     *     {
+     *         $validator = new Validation();
+     *         $validator->add("status",
+     *             new ExclusionIn(
+     *                 [
+     *                     "domain" => ["A", "I"]
+     *                 ]
+     *             )
+     *         );
+     *
+     *         return $this->validate($validator);
+     *     }
+     * }
+     * </code>
+     *
+     * @param mixed $validator
      */
-    protected function validate(Model\ValidatorInterface $validator) {}
+    protected function validate($validator) {}
 
     /**
      * Check whether validation process has generated any messages
@@ -611,6 +646,21 @@ abstract class Collection implements \Phalcon\Mvc\EntityInterface, \Phalcon\Mvc\
      * @return bool
      */
     public function delete() {}
+
+    /**
+     * Sets the dirty state of the object using one of the DIRTY_STATE_ constants
+     *
+     * @param int $dirtyState
+     * @return CollectionInterface
+     */
+    public function setDirtyState($dirtyState) {}
+
+    /**
+     * Returns one of the DIRTY_STATE_ constants telling if the document exists in the collection or not
+     *
+     * @return int
+     */
+    public function getDirtyState() {}
 
     /**
      * Sets up a behavior in a collection

--- a/ide/stubs/Phalcon/mvc/CollectionInterface.php
+++ b/ide/stubs/Phalcon/mvc/CollectionInterface.php
@@ -53,6 +53,21 @@ interface CollectionInterface
     public function getConnection();
 
     /**
+     * Sets the dirty state of the object using one of the DIRTY_STATE_ constants
+     *
+     * @param int $dirtyState
+     * @return \Phalcon\Mvc\CollectionInterface
+     */
+    public function setDirtyState($dirtyState);
+
+    /**
+     * Returns one of the DIRTY_STATE_ constants telling if the record exists in the database or not
+     *
+     * @return int
+     */
+    public function getDirtyState();
+
+    /**
      * Returns a cloned collection
      *
      * @param CollectionInterface $collection

--- a/ide/stubs/Phalcon/mvc/Micro.php
+++ b/ide/stubs/Phalcon/mvc/Micro.php
@@ -58,6 +58,12 @@ class Micro extends \Phalcon\Di\Injectable implements \ArrayAccess
     protected $_returnedValue;
 
 
+    protected $_modelBinder;
+
+
+    protected $_afterBindingHandlers;
+
+
     /**
      * Phalcon\Mvc\Micro constructor
      *
@@ -297,6 +303,14 @@ class Micro extends \Phalcon\Di\Injectable implements \ArrayAccess
     public function before($handler) {}
 
     /**
+     * Appends a afterBinding middleware to be called after model binding
+     *
+     * @param callable $handler
+     * @return Micro
+     */
+    public function afterBinding($handler) {}
+
+    /**
      * Appends an 'after' middleware to be called after execute the route
      *
      * @param callable $handler
@@ -318,5 +332,33 @@ class Micro extends \Phalcon\Di\Injectable implements \ArrayAccess
      * @return array
      */
     public function getHandlers() {}
+
+    /**
+     * Gets model binder
+     *
+     * @return null|\Phalcon\Mvc\Model\BinderInterface
+     */
+    public function getModelBinder() {}
+
+    /**
+     * Sets model binder
+     *
+     * <code>
+     * $micro = new Micro($di);
+     * $micro->setModelBinder(new Binder(), 'cache');
+     * </code>
+     *
+     * @param \Phalcon\Mvc\Model\BinderInterface $modelBinder
+     * @param mixed $cache
+     * @return Micro
+     */
+    public function setModelBinder(\Phalcon\Mvc\Model\BinderInterface $modelBinder, $cache = null) {}
+
+    /**
+     * Returns bound models from binder instance
+     *
+     * @return array
+     */
+    public function getBoundModels() {}
 
 }

--- a/ide/stubs/Phalcon/mvc/Model.php
+++ b/ide/stubs/Phalcon/mvc/Model.php
@@ -490,6 +490,7 @@ abstract class Model implements \Phalcon\Mvc\EntityInterface, \Phalcon\Mvc\Model
      * @param string $functionName
      * @param string $alias
      * @param array $parameters
+     * @param string $function
      * @return \Phalcon\Mvc\Model\ResultsetInterface
      */
     protected static function _groupResult($functionName, $alias, $parameters) {}
@@ -1289,7 +1290,17 @@ abstract class Model implements \Phalcon\Mvc\EntityInterface, \Phalcon\Mvc\Model
     public function hasChanged($fieldName = null) {}
 
     /**
-     * Returns a list of changed values
+     * Returns a list of changed values.
+     *
+     * <code>
+     * $robots = Robots::findFirst();
+     * print_r($robots->getChangedFields()); // []
+     *
+     * $robots->deleted = 'Y';
+     *
+     * $robots->getChangedFields();
+     * print_r($robots->getChangedFields()); // ["deleted"]
+     * </code>
      *
      * @return array
      */
@@ -1347,8 +1358,8 @@ abstract class Model implements \Phalcon\Mvc\EntityInterface, \Phalcon\Mvc\Model
     /**
      * Handles method calls when a method is not implemented
      *
-     * @param	string $method
-     * @param	array $arguments
+     * @param	string method
+     * @param	array arguments
      * @return	mixed
      * @param string $method
      * @param mixed $arguments
@@ -1358,8 +1369,8 @@ abstract class Model implements \Phalcon\Mvc\EntityInterface, \Phalcon\Mvc\Model
     /**
      * Handles method calls when a static method is not implemented
      *
-     * @param	string $method
-     * @param	array $arguments
+     * @param	string method
+     * @param	array arguments
      * @return	mixed
      * @param string $method
      * @param mixed $arguments

--- a/ide/stubs/Phalcon/mvc/micro/LazyLoader.php
+++ b/ide/stubs/Phalcon/mvc/micro/LazyLoader.php
@@ -13,6 +13,9 @@ class LazyLoader
     protected $_handler;
 
 
+    protected $_modelBinder;
+
+
     protected $_definition;
 
 
@@ -34,5 +37,15 @@ class LazyLoader
      * @return mixed
      */
     public function __call($method, $arguments) {}
+
+    /**
+     * Calling __call method
+     *
+     * @param string $method
+     * @param array $arguments
+     * @param \Phalcon\Mvc\Model\BinderInterface $modelBinder
+     * @return mixed
+     */
+    public function callMethod($method, $arguments, \Phalcon\Mvc\Model\BinderInterface $modelBinder = null) {}
 
 }

--- a/ide/stubs/Phalcon/mvc/model/Binder.php
+++ b/ide/stubs/Phalcon/mvc/model/Binder.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Phalcon\Mvc\Model;
+
+/**
+ * Phalcon\Mvc\Model\Binding
+ *
+ * This is an class for binding models into params for handler
+ */
+class Binder implements \Phalcon\Mvc\Model\BinderInterface
+{
+    /**
+     * Array for storing active bound models
+     *
+     * @var array
+     */
+    protected $boundModels = array();
+
+    /**
+     * Cache object used for caching parameters for model binding
+     */
+    protected $cache;
+
+    /**
+     * Internal cache for caching parameters for model binding during request
+     */
+    protected $internalCache = array();
+
+    /**
+     * Array for original values
+     */
+    protected $originalValues = array();
+
+
+    /**
+     * Array for storing active bound models
+     *
+     * @return array
+     */
+    public function getBoundModels() {}
+
+    /**
+     * Array for original values
+     */
+    public function getOriginalValues() {}
+
+    /**
+     * Phalcon\Mvc\Model\Binder constructor
+     *
+     * @param \Phalcon\Cache\BackendInterface $cache
+     */
+    public function __construct(\Phalcon\Cache\BackendInterface $cache = null) {}
+
+    /**
+     * Gets cache instance
+     *
+     * @param \Phalcon\Cache\BackendInterface $cache
+     * @return BinderInterface
+     */
+    public function setCache(\Phalcon\Cache\BackendInterface $cache) {}
+
+    /**
+     * Sets cache instance
+     *
+     * @return \Phalcon\Cache\BackendInterface
+     */
+    public function getCache() {}
+
+    /**
+     * Bind models into params in proper handler
+     *
+     * @param object $handler
+     * @param array $params
+     * @param string $cacheKey
+     * @param mixed $methodName
+     * @return array
+     */
+    public function bindToHandler($handler, array $params, $cacheKey, $methodName = null) {}
+
+    /**
+     * Get params classes from cache by key
+     *
+     * @param string $cacheKey
+     * @return array|null
+     */
+    protected function getParamsFromCache($cacheKey) {}
+
+    /**
+     * Get modified params for handler using reflection
+     *
+     * @param object $handler
+     * @param array $params
+     * @param string $cacheKey
+     * @param mixed $methodName
+     * @return array
+     */
+    protected function getParamsFromReflection($handler, array $params, $cacheKey, $methodName) {}
+
+}

--- a/ide/stubs/Phalcon/mvc/model/BinderInterface.php
+++ b/ide/stubs/Phalcon/mvc/model/BinderInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Phalcon\Mvc\Model;
+
+/**
+ * Phalcon\Mvc\Model\BinderInterface
+ *
+ * Interface for Phalcon\Mvc\Model\Binder
+ */
+interface BinderInterface
+{
+
+    /**
+     * Gets active bound models
+     *
+     * @return array
+     */
+    public function getBoundModels();
+
+    /**
+     * Gets cache instance
+     *
+     * @return \Phalcon\Cache\BackendInterface
+     */
+    public function getCache();
+
+    /**
+     * Sets cache instance
+     *
+     * @param \Phalcon\Cache\BackendInterface $cache
+     * @return BinderInterface
+     */
+    public function setCache(\Phalcon\Cache\BackendInterface $cache);
+
+    /**
+     * Bind models into params in proper handler
+     *
+     * @param object $handler
+     * @param array $params
+     * @param string $cacheKey
+     * @param string $methodName
+     * @return array
+     */
+    public function bindToHandler($handler, array $params, $cacheKey, $methodName = null);
+
+}

--- a/ide/stubs/Phalcon/mvc/model/Validator.php
+++ b/ide/stubs/Phalcon/mvc/model/Validator.php
@@ -7,8 +7,11 @@ namespace Phalcon\Mvc\Model;
  *
  * This is a base class for Phalcon\Mvc\Model validators
  *
- * This class is only for use with Phalcon\Mvc\Collection. If you are using
- * Phalcon\Mvc\Model, please use the validators provided by Phalcon\Validation.
+ * This class is only for backward compatibility reasons to use with Phalcon\Mvc\Collection.
+ * Otherwise please use the validators provided by Phalcon\Validation.
+ *
+ * @deprecated 3.1.0
+ * @see Phalcon\Validation\Validator
  */
 abstract class Validator implements \Phalcon\Mvc\Model\ValidatorInterface
 {

--- a/ide/stubs/Phalcon/mvc/model/ValidatorInterface.php
+++ b/ide/stubs/Phalcon/mvc/model/ValidatorInterface.php
@@ -6,6 +6,9 @@ namespace Phalcon\Mvc\Model;
  * Phalcon\Mvc\Model\ValidatorInterface
  *
  * Interface for Phalcon\Mvc\Model validators
+ *
+ * @deprecated 3.1.0
+ * @see Phalcon\Validation\ValidatorInterface
  */
 interface ValidatorInterface
 {

--- a/ide/stubs/Phalcon/mvc/model/binder/BindableInterface.php
+++ b/ide/stubs/Phalcon/mvc/model/binder/BindableInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Phalcon\Mvc\Model\Binder;
+
+/**
+ * Phalcon\Mvc\Model\Binder\BindableInterface
+ *
+ * Interface for bindable classes
+ */
+interface BindableInterface
+{
+
+    /**
+     * Return the model name or models names and parameters keys associated with this class
+     *
+     * @return string|array
+     */
+    abstract function getModelName();
+
+}

--- a/ide/stubs/Phalcon/mvc/model/binder/BindableInterface.php
+++ b/ide/stubs/Phalcon/mvc/model/binder/BindableInterface.php
@@ -15,6 +15,6 @@ interface BindableInterface
      *
      * @return string|array
      */
-    abstract function getModelName();
+    public function getModelName();
 
 }

--- a/ide/stubs/Phalcon/mvc/model/validator/Email.php
+++ b/ide/stubs/Phalcon/mvc/model/validator/Email.php
@@ -31,6 +31,9 @@ namespace Phalcon\Mvc\Model\Validator;
  *     }
  * }
  * </code>
+ *
+ * @deprecated 3.1.0
+ * @see Phalcon\Validation\Validator\Email
  */
 class Email extends \Phalcon\Mvc\Model\Validator
 {

--- a/ide/stubs/Phalcon/mvc/model/validator/Exclusionin.php
+++ b/ide/stubs/Phalcon/mvc/model/validator/Exclusionin.php
@@ -32,6 +32,9 @@ namespace Phalcon\Mvc\Model\Validator;
  *     }
  * }
  * </code>
+ *
+ * @deprecated 3.1.0
+ * @see Phalcon\Validation\Validator\EclusionIn
  */
 class Exclusionin extends \Phalcon\Mvc\Model\Validator
 {

--- a/ide/stubs/Phalcon/mvc/model/validator/Inclusionin.php
+++ b/ide/stubs/Phalcon/mvc/model/validator/Inclusionin.php
@@ -32,6 +32,9 @@ namespace Phalcon\Mvc\Model\Validator;
  *     }
  * }
  * </code>
+ *
+ * @deprecated 3.1.0
+ * @see Phalcon\Validation\Validator\InclusionIn
  */
 class Inclusionin extends \Phalcon\Mvc\Model\Validator
 {

--- a/ide/stubs/Phalcon/mvc/model/validator/Ip.php
+++ b/ide/stubs/Phalcon/mvc/model/validator/Ip.php
@@ -59,6 +59,8 @@ namespace Phalcon\Mvc\Model\Validator;
  *     }
  * }
  * </code>
+ *
+ * @deprecated 3.1.0
  */
 class Ip extends \Phalcon\Mvc\Model\Validator
 {

--- a/ide/stubs/Phalcon/mvc/model/validator/Numericality.php
+++ b/ide/stubs/Phalcon/mvc/model/validator/Numericality.php
@@ -31,6 +31,9 @@ namespace Phalcon\Mvc\Model\Validator;
  *     }
  * }
  * </code>
+ *
+ * @deprecated 3.1.0
+ * @see Phalcon\Validation\Validator\Numericality
  */
 class Numericality extends \Phalcon\Mvc\Model\Validator
 {

--- a/ide/stubs/Phalcon/mvc/model/validator/PresenceOf.php
+++ b/ide/stubs/Phalcon/mvc/model/validator/PresenceOf.php
@@ -32,6 +32,9 @@ namespace Phalcon\Mvc\Model\Validator;
  *     }
  * }
  * </code>
+ *
+ * @deprecated 3.1.0
+ * @see Phalcon\Validation\Validator\PresenceOf
  */
 class PresenceOf extends \Phalcon\Mvc\Model\Validator
 {

--- a/ide/stubs/Phalcon/mvc/model/validator/Regex.php
+++ b/ide/stubs/Phalcon/mvc/model/validator/Regex.php
@@ -32,6 +32,9 @@ namespace Phalcon\Mvc\Model\Validator;
  *     }
  * }
  * </code>
+ *
+ * @deprecated 3.1.0
+ * @see Phalcon\Validation\Validator\Regex
  */
 class Regex extends \Phalcon\Mvc\Model\Validator
 {

--- a/ide/stubs/Phalcon/mvc/model/validator/StringLength.php
+++ b/ide/stubs/Phalcon/mvc/model/validator/StringLength.php
@@ -35,6 +35,9 @@ namespace Phalcon\Mvc\Model\Validator;
  *     }
  * }
  * </code>
+ *
+ * @deprecated 3.1.0
+ * @see Phalcon\Validation\Validator\StringLength
  */
 class StringLength extends \Phalcon\Mvc\Model\Validator
 {

--- a/ide/stubs/Phalcon/mvc/model/validator/Uniqueness.php
+++ b/ide/stubs/Phalcon/mvc/model/validator/Uniqueness.php
@@ -34,6 +34,9 @@ namespace Phalcon\Mvc\Model\Validator;
  *     }
  * }
  * </code>
+ *
+ * @deprecated 3.1.0
+ * @see Phalcon\Validation\Validator\Uniqueness
  */
 class Uniqueness extends \Phalcon\Mvc\Model\Validator
 {

--- a/ide/stubs/Phalcon/mvc/model/validator/Url.php
+++ b/ide/stubs/Phalcon/mvc/model/validator/Url.php
@@ -31,6 +31,9 @@ namespace Phalcon\Mvc\Model\Validator;
  *     }
  * }
  * </code>
+ *
+ * @deprecated 3.1.0
+ * @see Phalcon\Validation\Validator\Url
  */
 class Url extends \Phalcon\Mvc\Model\Validator
 {

--- a/ide/stubs/Phalcon/validation/validator/Callback.php
+++ b/ide/stubs/Phalcon/validation/validator/Callback.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Phalcon\Validation\Validator;
+
+/**
+ * Phalcon\Validation\Validator\Callback
+ *
+ * Calls user function for validation
+ *
+ * <code>
+ * use Phalcon\Validation\Validator\Callback as CallbackValidator;
+ * use Phalcon\Validation\Validator\Numericality as NumericalityValidator;
+ *
+ * $validator->add(
+ *     ["user", "admin"],
+ *     new CallbackValidator(
+ *         [
+ *             "message" => "There must be only an user or admin set",
+ *             "callback" => function($data) {
+ *                 if (!empty($data->getUser()) && !empty($data->getAdmin())) {
+ *                     return false;
+ *                 }
+ *
+ *                 return true;
+ *             }
+ *         ]
+ *     )
+ * );
+ *
+ * $validator->add(
+ *     "amount",
+ *     new CallbackValidator(
+ *         [
+ *             "callback" => function($data) {
+ *                 if (!empty($data->getProduct())) {
+ *                     return new NumericalityValidator(
+ *                         [
+ *                             "message" => "Amount must be a number."
+ *                         ]
+ *                     );
+ *                 }
+ *             }
+ *         ]
+ *     )
+ * );
+ * </code>
+ */
+class Callback extends \Phalcon\Validation\Validator
+{
+
+    /**
+     * Executes the validation
+     *
+     * @param \Phalcon\Validation $validation
+     * @param string $field
+     * @return bool
+     */
+    public function validate(\Phalcon\Validation $validation, $field) {}
+
+}

--- a/ide/stubs/Phalcon/validation/validator/Exception.php
+++ b/ide/stubs/Phalcon/validation/validator/Exception.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Phalcon\Validation\Validator;
+
+/**
+ * Phalcon\Validation\Exception
+ *
+ * Exceptions thrown in Phalcon\Validation\Validator\ classes will use this class
+ */
+class Exception extends \Phalcon\Exception
+{
+
+}

--- a/ide/stubs/Phalcon/validation/validator/Uniqueness.php
+++ b/ide/stubs/Phalcon/validation/validator/Uniqueness.php
@@ -102,4 +102,22 @@ class Uniqueness extends \Phalcon\Validation\CombinedFieldsValidator
      */
     protected function getColumnNameReal($record, $field) {}
 
+    /**
+     * Uniqueness method used for model
+     *
+     * @param mixed $record
+     * @param array $field
+     * @param array $values
+     */
+    protected function isUniquenessModel($record, array $field, array $values) {}
+
+    /**
+     * Uniqueness method used for collection
+     *
+     * @param mixed $record
+     * @param array $field
+     * @param array $values
+     */
+    protected function isUniquenessCollection($record, array $field, array $values) {}
+
 }

--- a/phalcon.php
+++ b/phalcon.php
@@ -34,6 +34,7 @@ use Phalcon\Commands\Builtin\AllModels;
 use Phalcon\Commands\Builtin\Migration;
 use Phalcon\Commands\Builtin\Enumerate;
 use Phalcon\Commands\Builtin\Controller;
+use Phalcon\Commands\Builtin\Console;
 use Phalcon\Exception as PhalconException;
 use Phalcon\Events\Manager as EventsManager;
 
@@ -60,6 +61,7 @@ try {
         Scaffold::class,
         Migration::class,
         Webtools::class,
+        Console::class,
     ];
 
     $script->loadUserScripts();

--- a/scripts/Phalcon/Commands/Builtin/Console.php
+++ b/scripts/Phalcon/Commands/Builtin/Console.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+  +------------------------------------------------------------------------+
+  | Phalcon Developer Tools                                                |
+  +------------------------------------------------------------------------+
+  | Copyright (c) 2011-2016 Phalcon Team (https://www.phalconphp.com)      |
+  +------------------------------------------------------------------------+
+  | This source file is subject to the New BSD License that is bundled     |
+  | with this package in the file LICENSE.txt.                             |
+  |                                                                        |
+  | If you did not receive a copy of the license and are unable to         |
+  | obtain it through the world-wide-web, please send an email             |
+  | to license@phalconphp.com so we can send you a copy immediately.       |
+  +------------------------------------------------------------------------+
+  | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+  |          Eduar Carvajal <eduar@phalconphp.com>                         |
+  |          Rodrigo Ramos <rodrigoramosrx2@gmail.com>                     |
+  +------------------------------------------------------------------------+
+*/
+
+namespace Phalcon\Commands\Builtin;
+
+use Phalcon\Script\Color;
+use Phalcon\Commands\Command;
+use Phalcon\Utils\SystemInfo;
+use Psy\Shell;
+use Psy\Configuration;
+
+/**
+ * Console Command
+ *
+ * @package Phalcon\Commands\Builtin
+ */
+class Console extends Command
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @return array
+     */
+    public function getPossibleParams()
+    {
+        return [
+            'include=s'    => 'Script to include [optional]',
+            'help' => 'Shows this help [optional]',
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param array $parameters
+     * @return mixed
+     */
+    public function run(array $parameters)
+    {
+        $config = new Configuration;
+        $shell = new Shell($config);
+        
+        if ($this->isReceivedOption('include')) {
+            $shell->setIncludes([substr($this->getOption('include'), 2)]);
+        }
+
+        $shell->run();
+
+        return 0;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return array
+     */
+    public function getCommands()
+    {
+        return ['console', 'shell', 'psysh'];
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return boolean
+     */
+    public function canBeExternal()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return void
+     */
+    public function getHelp()
+    {
+        print Color::head('Help:') . PHP_EOL;
+        print Color::colorize('  Start a runtime developer console') . PHP_EOL . PHP_EOL;
+        $this->printParameters($this->getPossibleParams());
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return integer
+     */
+    public function getRequiredParams()
+    {
+        return 0;
+    }
+}

--- a/scripts/Phalcon/Commands/Builtin/Module.php
+++ b/scripts/Phalcon/Commands/Builtin/Module.php
@@ -41,13 +41,14 @@ class Module extends Command
     public function getPossibleParams()
     {
         return [
-            'name'            => 'Name of the new module',
-            'namespace=s'     => "Module's namespace [optional]",
-            'output=s'        => 'Folder where modules are located [optional]',
-            'config-type=s'   => 'The config type to be generated (ini, json, php, yaml) [optional]',
-            'template-path=s' => 'Specify a template path [optional]',
-            'help'            => 'Shows this help [optional]',
-
+            'name'                 => 'Name of the new module',
+            'namespace=s'          => "Module's namespace [optional]",
+            'output=s'             => 'Folder where modules are located [optional]',
+            'config-type=s'        => 'The config type to be generated (ini, json, php, yaml) [optional]',
+            'template-path=s'      => 'Specify a template path [optional]',
+            'module-directories=s' => 'What directories to create in module [optional]',
+            'namespace-alias=s'    => 'How to call model namespace alias in module [optional]',
+            'help'                 => 'Shows this help [optional]',
         ];
     }
 
@@ -59,18 +60,22 @@ class Module extends Command
      */
     public function run(array $parameters)
     {
-        $moduleName   = $this->getOption(['name', 1]);
-        $namespace    = $this->getOption('namespace', null, 'Application');
-        $configType   = $this->getOption('config-type', null, 'php');
-        $modulesDir   = $this->getOption('output');
-        $templatePath = $this->getOption('template-path', null, TEMPLATE_PATH . DIRECTORY_SEPARATOR . 'module');
+        $moduleName = $this->getOption(['name', 1]);
+        $namespace = $this->getOption('namespace', null, 'Application');
+        $configType = $this->getOption('config-type', null, 'php');
+        $modulesDir = $this->getOption('output');
+        $namespaceAlias = $this->getOption('namespace-alias');
+        $moduleDirectories = $this->getOption('module-directories');
+        $templatePath = $this->getOption('template-path', null, TEMPLATE_PATH.DIRECTORY_SEPARATOR.'module');
 
         $builder = new ModuleBuilder([
-            'name'         => $moduleName,
-            'namespace'    => $namespace,
-            'config-type'  => $configType,
-            'templatePath' => $templatePath,
-            'modulesDir'   => $modulesDir
+            'name'               => $moduleName,
+            'namespace'          => $namespace,
+            'config-type'        => $configType,
+            'templatePath'       => $templatePath,
+            'modulesDir'         => $modulesDir,
+            'namespace-alias'    => $namespaceAlias,
+            'module-directories' => $moduleDirectories,
         ]);
 
         return $builder->build();

--- a/scripts/Phalcon/Devtools/Version.php
+++ b/scripts/Phalcon/Devtools/Version.php
@@ -39,6 +39,6 @@ class Version extends PhVersion
      */
     protected static function _getVersion()
     {
-        return [3, 0, 4, 0, 0];
+        return [3, 0, 5, 0, 0];
     }
 }

--- a/templates/project/modules/bootstrap_web.php
+++ b/templates/project/modules/bootstrap_web.php
@@ -53,7 +53,7 @@ try {
      */
     require APP_PATH . '/config/routes.php';
 
-    echo $application->handle()->getContent();
+    echo str_replace(["\n","\r","\t"], '', $application->handle()->getContent());
 
 } catch (\Exception $e) {
     echo $e->getMessage() . '<br>';

--- a/templates/project/simple/index.php
+++ b/templates/project/simple/index.php
@@ -39,7 +39,7 @@ try {
      */
     $application = new \Phalcon\Mvc\Application($di);
 
-    echo $application->handle()->getContent();
+    echo str_replace(["\n","\r","\t"], '', $application->handle()->getContent());
 
 } catch (\Exception $e) {
     echo $e->getMessage() . '<br>';


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue:

This pull request affects the following components: **(please check boxes)**

- [x] Core
- [ ] WebTools
- [ ] Migrations
- [ ] Models
- [x] Scaffold
- [ ] Documentation
- [ ] IDE
- [ ] MySQL
- [ ] PostgreSQL
- [ ] Oracle
- [ ] SQLite
- [ ] Testing
- [ ] Code Quality
- [x] Templating

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: This PR is adding two things - one is way to tell which directories we want to create when creating module, providing them by comma seperated string. Other thing is `namespace-alias` for model namespace aliases, in my application i have template like:

```php
<?php

namespace @@FQMN@@;

use Phalcon\Config\Adapter\Ini;
use Phalcon\Di;
use Phalcon\DiInterface;
use Phalcon\Loader;
use Phalcon\Mvc\Model\Manager;
use Phalcon\Mvc\ModuleDefinitionInterface;

/**
 * Class Module
 *
 * @package @@FQMN@@
 */
class Module implements ModuleDefinitionInterface
{
    /**
     * Register namespace aliases for PHQL
     */
    public static function registerNamespaceAlias()
    {
        /** @var Manager $modelsManager */
        $modelsManager = Di::getDefault()->getShared('modelsManager');
        $modelsManager->registerNamespaceAlias('@@MNA@@', '@@FQMN@@\Model');
    }
```

This registerNamespaceAlias is called on boostraping of application. This way i can set my model namespace alias when creating module from cli.

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
