### PR TITLE
Fix:

### DIFF
--- a/scripts/Phalcon/Builder/AllModels.php
+++ b/scripts/Phalcon/Builder/AllModels.php
@@ -200,6 +200,7 @@ class AllModels extends Component
                     'belongsTo' => $belongsToModel,
                     'foreignKeys' => $foreignKeysModel,
                     'genSettersGetters' => $genSettersGetters,
+                    'genDocMethods' => $this->options->get('genDocMethods'),
                     'directory' => $this->options->get('directory'),
                     'modelsDir' => $this->options->get('modelsDir'),
                     'mapColumn' => $mapColumn,

--- a/scripts/Phalcon/Generator/Snippet.php
+++ b/scripts/Phalcon/Generator/Snippet.php
@@ -249,7 +249,7 @@ EOD;
      * Allows to query a set of records that match the specified conditions
      *
      * @param mixed \$parameters
-     * @return %s[]|%s
+     * @return %s[]|%s|\Phalcon\Mvc\Model\ResultSetInterface
      */
     public static function find(\$parameters = null)
     {
@@ -266,7 +266,7 @@ EOD;
      * Allows to query the first record that match the specified conditions
      *
      * @param mixed \$parameters
-     * @return %s
+     * @return %s|\Phalcon\Mvc\Model\ResultInterface
      */
     public static function findFirst(\$parameters = null)
     {


### PR DESCRIPTION
1."phalcon all-models --doc" could't generate document for model-class.
2. PhpStrom warning: Return value type is not compatible with declared.

Hello!

* Type: bug fix | code quality
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:

1. "phalcon all-models --doc" will generate document for class. like this:

`	<?php`
`	/**`
`	 * Robots`
`	 * @date 2017-04-29 05:30:34`
`	 */`
`	class Robots`
`	{`
`	}`

2. phpstrom warning: Return value type is not compatible with declared.

`	public static function find($parameters = null)`
`	{`
`		//PhpStrom warning: Return value type is not compatible with declared.`
`		return parent::find($parameters);`
`	}`

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md