### PR TITLE
fix migration for all tables in webtools

### DIFF
--- a/scripts/Phalcon/Web/Tools/Controllers/MigrationsController.php
+++ b/scripts/Phalcon/Web/Tools/Controllers/MigrationsController.php
@@ -157,7 +157,7 @@ class MigrationsController extends Base
                     [
                         'config'        => $this->config,
                         'directory'     => $this->request->getPost('basePath', 'string'),
-                        'tableName'     => 'all', // @todo
+                        'tableName'     => '@', // @todo
                         'migrationsDir' => $this->request->getPost('migrationsDir', 'string'),
                     ]
                 );


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: -

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:
According to devtools/scripts/Phalcon/Migrations.php 276 line, Should be "@", not "all". And this fixed migration "run" from webtools, before that they did not do anything. (at least for me)
Correct me please if I'm wrong

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
