### PR TITLE
directly link js_ie files to avoid slowing down the request

### DIFF
--- a/scripts/Phalcon/Mvc/Controller/Base.php
+++ b/scripts/Phalcon/Mvc/Controller/Base.php
@@ -108,12 +108,8 @@ abstract class Base extends Controller
 
         $this->assets
             ->collection('js_ie')
-            ->setTargetPath('js/webtools-ie.js')
-            ->setTargetUri('js/webtools-ie.js?v=' . Version::get())
             ->addJs('https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js', false, false)
-            ->addJs('https://oss.maxcdn.com/respond/1.4.2/respond.min.js', false, false)
-            ->join(true)
-            ->addFilter(new Jsmin);
+            ->addJs('https://oss.maxcdn.com/respond/1.4.2/respond.min.js', false, false);
 
         return $this;
     }


### PR DESCRIPTION
Hello!

* Type: suggest , 
* Link to issue: 

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:

I found webtools.php slowed down by remote request js_ie related js files, and it also requires openssl opened, or the page will be blank.   
I think it is not necessary to combine and compress the few used js files which are remote files.   

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
