### PR TITLE
Add Serve Builtin Command to Devtools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,22 @@ env:
     - DISPLAY=":99.0"
     - PHALCON_VERSION="v3.0.4"
 
+before_install:
+  - export PHP_VERSION=$(php-config --version)
+  - export PHP_EXTENSION_DIR=$(php-config --extension-dir)
+  - phpenv config-rm xdebug.ini || true
+  - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com $GH_TOKEN; fi;
+  - if [ ! -f "$HOME/cphalcon/tests/_ci/phalcon.ini" ]; then git clone -q --depth=1 https://github.com/phalcon/cphalcon.git $HOME/cphalcon >/dev/null 2>&1; fi;
+
+install:
+  - if [ ! -f $HOME/ext/$PHP_VERSION/phalcon.so ]; then cd $HOME/cphalcon/build && bash ./install --phpize $(phpenv which phpize) --php-config $(phpenv which php-config) && mkdir -p $HOME/ext/$PHP_VERSION && cp $PHP_EXTENSION_DIR/phalcon.so $HOME/ext/$PHP_VERSION/phalcon.so; fi;
+  - if [ -f $HOME/ext/$PHP_VERSION/phalcon.so ]; then cp $HOME/ext/$PHP_VERSION/phalcon.so $PHP_EXTENSION_DIR/phalcon.so; fi;
+  - phpenv config-add $HOME/cphalcon/tests/_ci/phalcon.ini
+  - cd $TRAVIS_BUILD_DIR
+  - travis_retry composer install --prefer-dist --no-interaction
+
 script:
-  - true
+  - vendor/bin/codecept run unit
 
 notifications:
   email:
@@ -52,3 +66,4 @@ addons:
       - mysql-server-5.6
       - mysql-client-core-5.6
       - mysql-client-5.6
+language: php

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Available commands:
   scaffold         (alias of: create-scaffold)
   migration        (alias of: create-migration)
   webtools         (alias of: create-webtools)
+  serve            (alias of: server)
   console          (alias of: shell, psysh)
 ```
 

--- a/codeception.yml
+++ b/codeception.yml
@@ -1,0 +1,10 @@
+paths:
+    tests: tests
+    output: tests/_output
+    data: tests/_data
+    support: tests/_support
+    envs: tests/_envs
+actor_suffix: Tester
+extensions:
+    enabled:
+        - Codeception\Extension\RunFailed

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,10 @@
         "psy/psysh": "@stable"
     },
     "require-dev": {
-        "kherge/box": "^2.7"
+        "kherge/box": "^2.7",
+        "codeception/codeception": "^2.3",
+        "phpdocumentor/reflection-docblock": "^2.0",
+        "phpunit/phpunit": "^4.8"
     },
     "autoload": {
         "psr-4" : {

--- a/phalcon.php
+++ b/phalcon.php
@@ -34,6 +34,7 @@ use Phalcon\Commands\Builtin\AllModels;
 use Phalcon\Commands\Builtin\Migration;
 use Phalcon\Commands\Builtin\Enumerate;
 use Phalcon\Commands\Builtin\Controller;
+use Phalcon\Commands\Builtin\Serve;
 use Phalcon\Commands\Builtin\Console;
 use Phalcon\Exception as PhalconException;
 use Phalcon\Events\Manager as EventsManager;
@@ -61,6 +62,7 @@ try {
         Scaffold::class,
         Migration::class,
         Webtools::class,
+        Serve::class,
         Console::class,
     ];
 

--- a/scripts/Phalcon/Commands/Builtin/Serve.php
+++ b/scripts/Phalcon/Commands/Builtin/Serve.php
@@ -41,6 +41,11 @@ class Serve extends Command
     const DEFAULT_PORT      = '8080';
     const DEFAULT_BASE_PATH = 'public/index.php';
 
+    protected $_hostname = '';
+    protected $_port = '';
+    protected $_base_path = '';
+    protected $_config = '';
+
     /**
      * {@inheritdoc}
      *
@@ -74,34 +79,63 @@ class Serve extends Command
         passthru($cmd);
     }
 
-    protected function shellCommand()
+    /**
+     * {@inheritdoc}
+     *
+     * @return void
+     */
+    public function prepareOptions()
+    {
+        $this->_hostname  = $this->getOption(['hostname', 1], null, self::DEFAULT_HOSTNAME);
+        $this->_port      = $this->getOption(['port',     2], null, self::DEFAULT_PORT);
+        $this->_base_path = $this->getOption(['basepath', 3], null, self::DEFAULT_BASE_PATH);
+        $this->_config    = $this->customConfig($this->getOption(['config']));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return void
+     */
+    public function printServerDetails()
+    {
+        print Color::head('Preparing Development Server') . PHP_EOL;
+        print Color::colorize("  Host: $this->_hostname", Color::FG_GREEN) . PHP_EOL;
+        print Color::colorize("  Port: $this->_port", Color::FG_GREEN) . PHP_EOL;
+        print Color::colorize("  Base: $$this->_base_path", Color::FG_GREEN) . PHP_EOL;
+        if($this->_config != null) {
+            print Color::colorize("   ini: $$this->_config", Color::FG_GREEN) . PHP_EOL;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function shellCommand()
     {
         $systemInfo = new SystemInfo();
-
         $binary_path = $systemInfo->getEnvironment()['PHP Bin'];
 
-        $hostname =  $this->getOption(['hostname', 1], null, self::DEFAULT_HOSTNAME);
-        $port =      $this->getOption(['port',     2], null, self::DEFAULT_PORT);
-        $base_path = $this->getOption(['basepath', 3], null, self::DEFAULT_BASE_PATH);
-        $config = $this->customConfig($this->getOption(['config']));
-
-        print Color::head('Preparing Development Server') . PHP_EOL;
-        print Color::colorize("  Host: $hostname", Color::FG_GREEN) . PHP_EOL;
-        print Color::colorize("  Port: $port", Color::FG_GREEN) . PHP_EOL;
-        print Color::colorize("  Base: $base_path", Color::FG_GREEN) . PHP_EOL;
-        if($config != null) {
-            print Color::colorize("   ini: $config", Color::FG_GREEN) . PHP_EOL;
-        }
+        $this->prepareOptions();
+        $this->printServerDetails();
 
         return sprintf('%s -S %s:%s %s %s',
             $binary_path,
-            $hostname,
-            $port,
-            'public/index.php',
-            $config
+            $this->_hostname,
+            $this->_port,
+            $this->_base_path,
+            $this->_config
         );
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @param  string
+     * @return string
+     */
     protected function customConfig($config){
         if ($config === null) {
             return '';
@@ -150,5 +184,45 @@ class Serve extends Command
     public function getRequiredParams()
     {
         return 0;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function getHostname()
+    {
+        return $this->_hostname;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function getPort()
+    {
+        return $this->_port;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function getBasePath()
+    {
+        return $this->_base_path;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function getConfigPath()
+    {
+        return $this->_config;
     }
 }

--- a/scripts/Phalcon/Commands/Builtin/Serve.php
+++ b/scripts/Phalcon/Commands/Builtin/Serve.php
@@ -1,0 +1,144 @@
+<?php
+
+/*
+  +------------------------------------------------------------------------+
+  | Phalcon Developer Tools                                                |
+  +------------------------------------------------------------------------+
+  | Copyright (c) 2011-2017 Phalcon Team (https://www.phalconphp.com)      |
+  +------------------------------------------------------------------------+
+  | This source file is subject to the New BSD License that is bundled     |
+  | with this package in the file LICENSE.txt.                             |
+  |                                                                        |
+  | If you did not receive a copy of the license and are unable to         |
+  | obtain it through the world-wide-web, please send an email             |
+  | to license@phalconphp.com so we can send you a copy immediately.       |
+  +------------------------------------------------------------------------+
+  | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+  |          Eduar Carvajal <eduar@phalconphp.com>                         |
+  |          Paul Scarrone <paul@savvysoftworks.com>                       |
+  +------------------------------------------------------------------------+
+*/
+
+namespace Phalcon\Commands\Builtin;
+
+use Phalcon\Script\Color;
+use Phalcon\Commands\Command;
+use Phalcon\Utils\SystemInfo;
+use Phalcon\Registry;
+use Phalcon\DI\FactoryDefault;
+use Phalcon\Bootstrap;
+
+/**
+ * Serve Command
+ *
+ * Launch the built-in PHP development server
+ *
+ * @package Phalcon\Commands\Builtin
+ */
+class Serve extends Command
+{
+    const DEFAULT_HOSTNAME  = '0.0.0.0';
+    const DEFAULT_PORT      = '8080';
+    const DEFAULT_BASE_PATH = 'public/index.php';
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return array
+     */
+    public function getPossibleParams()
+    {
+        return [
+            'hostname=s'        => 'Server Hostname [default='.self::DEFAULT_HOSTNAME.']',
+            'port=s'            => 'Server Port [default='.self::DEFAULT_PORT.']',
+            'basepath=s'        => 'Project entry-point [default='.self::DEFAULT_BASE_PATH.']',
+            'config=s'          => 'Server configuration ini [optional]',
+            'help'              => 'Shows this help [optional]',
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param array $parameters
+     * @return mixed
+     */
+    public function run(array $parameters)
+    {
+        $di = new FactoryDefault();
+        $di['registry'] = function () {
+            return new Registry();
+        };
+        passthru($this->shellCommand());
+    }
+
+    protected function shellCommand()
+    {
+        $systemInfo = new SystemInfo();
+
+        $binary_path = $systemInfo->getEnvironment()['PHP Bin'];
+
+        $hostname =  $this->getOption(['hostname', 1], null, self::DEFAULT_HOSTNAME);
+        $port =      $this->getOption(['port',     2], null, self::DEFAULT_PORT);
+        $base_path = $this->getOption(['basepath', 3], null, self::DEFAULT_BASE_PATH);
+        $config = $this->customConfig($this->getOption(['config']));
+
+        return sprintf('%s -S %s:%s %s %s',
+            $binary_path,
+            $hostname,
+            $port,
+            'public/index.php',
+            $config
+        );
+    }
+
+    protected function customConfig($config){
+        if ($config === null) {
+            return '';
+        } else {
+            return sprintf('-c %s', $config);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return array
+     */
+    public function getCommands()
+    {
+        return ['serve', 'server'];
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return void
+     */
+    public function getHelp()
+    {
+        print Color::head('Help:') . PHP_EOL;
+        print Color::colorize('  Launch the built-in PHP development server') . PHP_EOL . PHP_EOL;
+
+        print Color::head('Usage:') . PHP_EOL;
+        print Color::colorize('  serve [hostname] [port]', Color::FG_GREEN) . PHP_EOL . PHP_EOL;
+
+        print Color::head('Arguments:') . PHP_EOL;
+        print Color::colorize('  config', Color::FG_GREEN);
+        print Color::colorize("\tSpecify a custom php.ini") . PHP_EOL . PHP_EOL;
+        print Color::colorize('  help', Color::FG_GREEN);
+        print Color::colorize("\t\tShows this help text") . PHP_EOL . PHP_EOL;
+
+        $this->printParameters($this->getPossibleParams());
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return integer
+     */
+    public function getRequiredParams()
+    {
+        return 0;
+    }
+}

--- a/scripts/Phalcon/Commands/Builtin/Serve.php
+++ b/scripts/Phalcon/Commands/Builtin/Serve.php
@@ -69,7 +69,9 @@ class Serve extends Command
         $di['registry'] = function () {
             return new Registry();
         };
-        passthru($this->shellCommand());
+        $cmd = $this->shellCommand();
+        print Color::head("Starting Server with $cmd") . PHP_EOL . PHP_EOL;
+        passthru($cmd);
     }
 
     protected function shellCommand()
@@ -82,6 +84,14 @@ class Serve extends Command
         $port =      $this->getOption(['port',     2], null, self::DEFAULT_PORT);
         $base_path = $this->getOption(['basepath', 3], null, self::DEFAULT_BASE_PATH);
         $config = $this->customConfig($this->getOption(['config']));
+
+        print Color::head('Preparing Development Server') . PHP_EOL;
+        print Color::colorize("  Host: $hostname", Color::FG_GREEN) . PHP_EOL;
+        print Color::colorize("  Port: $port", Color::FG_GREEN) . PHP_EOL;
+        print Color::colorize("  Base: $base_path", Color::FG_GREEN) . PHP_EOL;
+        if($config != null) {
+            print Color::colorize("   ini: $config", Color::FG_GREEN) . PHP_EOL;
+        }
 
         return sprintf('%s -S %s:%s %s %s',
             $binary_path,

--- a/tests/_output/.gitignore
+++ b/tests/_output/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/_support/Helper/Unit.php
+++ b/tests/_support/Helper/Unit.php
@@ -1,0 +1,14 @@
+<?php
+namespace Helper;
+
+use Codeception\Util\Autoload;
+
+AutoLoad::addNamespace('Phalcon', '/scripts/Phalcon');
+
+// here you can define custom actions
+// all public methods declared in helper class will be available in $I
+
+class Unit extends \Codeception\Module
+{
+
+}

--- a/tests/_support/UnitTester.php
+++ b/tests/_support/UnitTester.php
@@ -1,0 +1,26 @@
+<?php
+
+
+/**
+ * Inherited Methods
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ * @method \Codeception\Lib\Friend haveFriend($name, $actorClass = NULL)
+ *
+ * @SuppressWarnings(PHPMD)
+*/
+class UnitTester extends \Codeception\Actor
+{
+    use _generated\UnitTesterActions;
+
+   /**
+    * Define custom actions here
+    */
+}

--- a/tests/_support/_generated/.gitignore
+++ b/tests/_support/_generated/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/unit.suite.yml
+++ b/tests/unit.suite.yml
@@ -1,0 +1,9 @@
+# Codeception Test Suite Configuration
+#
+# Suite for unit or integration tests.
+
+actor: UnitTester
+modules:
+    enabled:
+        - Asserts
+        - \Helper\Unit

--- a/tests/unit/ServeTest.php
+++ b/tests/unit/ServeTest.php
@@ -1,0 +1,205 @@
+<?php
+
+/*
+  +------------------------------------------------------------------------+
+  | Phalcon Developer Tools                                                |
+  +------------------------------------------------------------------------+
+  | Copyright (c) 2011-2017 Phalcon Team (https://www.phalconphp.com)      |
+  +------------------------------------------------------------------------+
+  | This source file is subject to the New BSD License that is bundled     |
+  | with this package in the file LICENSE.txt.                             |
+  |                                                                        |
+  | If you did not receive a copy of the license and are unable to         |
+  | obtain it through the world-wide-web, please send an email             |
+  | to license@phalconphp.com so we can send you a copy immediately.       |
+  +------------------------------------------------------------------------+
+  | Authors: Paul Scarrone <paul@savvysoftworks.com>                       |
+  +------------------------------------------------------------------------+
+*/
+
+use Phalcon\Commands\Builtin\Serve;
+use Phalcon\Commands\CommandsListener;
+use Phalcon\Script;
+use Phalcon\Events\Manager as EventsManager;
+
+class ServeTest extends \Codeception\Test\Unit
+{
+    protected $command = null;
+
+    public function _before()
+    {
+        $eventsManager = new EventsManager();
+        $eventsManager->attach('command', new CommandsListener());
+        $script = new Script($eventsManager);
+        $this->command = new Serve($script, $eventsManager);
+        //$this->command->activateTestMode();
+    }
+
+    public function _after()
+    {
+        //$this->command->resetTestMode();
+    }
+
+    /**
+     * Verify that is no arguments are passed via the command line
+     * this will provide a valid default configuration
+     *
+     * @author Paul Scarrone <paul@savvysoftworks.com>
+     */
+    public function testDefaultValuesWithNoParameters()
+    {
+        $_SERVER['argv'] = ['',''];
+        $this->command->parseParameters([], []);
+        $this->command->prepareOptions();
+        $this->assertEquals('0.0.0.0', $this->command->getHostname());
+        $this->assertEquals('8080', $this->command->getPort());
+        $this->assertEquals('public/index.php', $this->command->getBasePath());
+        $this->assertEmpty($this->command->getConfigPath());
+    }
+
+    /**
+     * Verify that is no arguments are passed via the command line
+     * this will provide a valid default configuration
+     *
+     * @author Paul Scarrone <paul@savvysoftworks.com>
+     */
+    public function testGeneratedCommandWithNoParameters()
+    {
+        $_SERVER['argv'] = ['',''];
+        $this->command->parseParameters([], []);
+        $command = $this->command->shellCommand();
+        $this->assertContains('php -S 0.0.0.0:8080 public/index.php', $command);
+    }
+
+    /**
+     * Verify that is no arguments are passed via the command line
+     * this will provide a valid default configuration when only the
+     * hostname is provided
+     *
+     * @author Paul Scarrone <paul@savvysoftworks.com>
+     */
+    public function testDefaultValuesWithHostnameOnly()
+    {
+        $_SERVER['argv'] = ['','', 'localhost'];
+        $this->command->parseParameters([], []);
+        $this->command->prepareOptions();
+        $this->assertEquals('localhost', $this->command->getHostname());
+        $this->assertEquals('8080', $this->command->getPort());
+        $this->assertEquals('public/index.php', $this->command->getBasePath());
+        $this->assertEmpty($this->command->getConfigPath());
+    }
+
+    /**
+     * Verify that is no arguments are passed via the command line
+     * this will provide a valid default configuration when only the
+     * hostname is provided
+     *
+     * @author Paul Scarrone <paul@savvysoftworks.com>
+     */
+    public function testGeneratedCommandWithHostnameOnly()
+    {
+        $_SERVER['argv'] = ['','', 'localhost'];
+        $this->command->parseParameters([], []);
+        $command = $this->command->shellCommand();
+        $this->assertContains('php -S localhost:8080 public/index.php', $command);
+    }
+
+    /**
+     * Verify that is no arguments are passed via the command line
+     * this will provide a valid default configuration when only the
+     * port is provided
+     *
+     * @author Paul Scarrone <paul@savvysoftworks.com>
+     */
+    public function testDefaultValuesWithPortOnly()
+    {
+        $_SERVER['argv'] = ['','', null, 1111];
+        $this->command->parseParameters([], []);
+        $this->command->prepareOptions();
+        $this->assertEquals('0.0.0.0', $this->command->getHostname());
+        $this->assertEquals('1111', $this->command->getPort());
+        $this->assertEquals('public/index.php', $this->command->getBasePath());
+        $this->assertEmpty($this->command->getConfigPath());
+    }
+
+    /**
+     * Verify that is no arguments are passed via the command line
+     * this will provide a valid default configuration when only the
+     * port is provided
+     *
+     * @author Paul Scarrone <paul@savvysoftworks.com>
+     */
+    public function testGeneratedCommandWithPortOnly()
+    {
+        $_SERVER['argv'] = ['','', null, 1111];
+        $this->command->parseParameters([], []);
+        $command = $this->command->shellCommand();
+        $this->assertContains('php -S 0.0.0.0:1111 public/index.php', $command);
+    }
+
+    /**
+     * Verify that is no arguments are passed via the command line
+     * this will provide a valid default configuration when only the
+     * basepath is provided
+     *
+     * @author Paul Scarrone <paul@savvysoftworks.com>
+     */
+    public function testDefaultValuesWithBasepathOnly()
+    {
+        $_SERVER['argv'] = ['','', null, null, '/root/bin.php'];
+        $this->command->parseParameters([], []);
+        $this->command->prepareOptions();
+        $this->assertEquals('0.0.0.0', $this->command->getHostname());
+        $this->assertEquals('8080', $this->command->getPort());
+        $this->assertEquals('/root/bin.php', $this->command->getBasePath());
+        $this->assertEmpty($this->command->getConfigPath());
+    }
+
+    /**
+     * Verify that is no arguments are passed via the command line
+     * this will provide a valid default configuration when only the
+     * basepath is provided
+     *
+     * @author Paul Scarrone <paul@savvysoftworks.com>
+     */
+    public function testGeneratedCommandWithBasepathOnly()
+    {
+        $_SERVER['argv'] = ['','', null, null, '/root/bin.php'];
+        $this->command->parseParameters([], []);
+        $command = $this->command->shellCommand();
+        $this->assertContains('php -S 0.0.0.0:8080 /root/bin.php', $command);
+    }
+
+    /**
+     * Verify that is no arguments are passed via the command line
+     * this will provide a valid default configuration when only the
+     * config is provided
+     *
+     * @author Paul Scarrone <paul@savvysoftworks.com>
+     */
+    public function testDefaultValuesWithConfigOnly()
+    {
+        $_SERVER['argv'] = ['','', null, null, null, '--config=awesome.ini'];
+        $this->command->parseParameters([], []);
+        $this->command->prepareOptions();
+        $this->assertEquals('0.0.0.0', $this->command->getHostname());
+        $this->assertEquals('8080', $this->command->getPort());
+        $this->assertEquals('public/index.php', $this->command->getBasePath());
+        $this->assertEquals('-c awesome.ini', $this->command->getConfigPath());
+    }
+
+    /**
+     * Verify that is no arguments are passed via the command line
+     * this will provide a valid default configuration when only the
+     * config is provided
+     *
+     * @author Paul Scarrone <paul@savvysoftworks.com>
+     */
+    public function testGeneratedCommandWithConfigOnly()
+    {
+        $_SERVER['argv'] = ['','', null, null, null, '--config=awesome.ini'];
+        $this->command->parseParameters([], []);
+        $command = $this->command->shellCommand();
+        $this->assertContains('php -S 0.0.0.0:8080 public/index.php -c awesome.ini', $command);
+    }
+}


### PR DESCRIPTION
Hello!

* Type: __new feature__ | __code quality__
* Link to issue: __No Issue__

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR (Added _Codeception_ to the project)

Small description of change:
In preparation for my meetup on July 20th I want to simplify the number of commands required to get a new project up and running. From Devtools a user can create an empty project and then immediately launch a development server to build up a hello world application.

In general this is inspired by the `rails server` command I use with RoR. This server is not expected to take the place of nGINx or Apache but when onboarding new users who man not have ever installed a webserver or are running windows. Using the builtin PHP webserver will keep users more focused on Phalcon and less on dependencies.

This is really a simple command that launches a blocking php process and the only reason this file isn't 10 lines long is because I am allowing for additional convention over configuration CLI options in addition to providing an alternative php.ini file for those who are currently building and developing
Zephir packages or Phalcon core features without modifying the language ini. This will allow for lightweight A/B performance examinations between multiple versions of the compiled extension.

###### Usage
- $`phalcon serve`
- $`phalcon serve localhost 6000 public/admin.php --config alt.ini`

Sincerely,
Paul Scarrone

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
