### PR TITLE
Added describeReferences method in postgresql DB

### DIFF
--- a/scripts/Phalcon/Db/Adapter/Pdo/PostgresqlExtended.php
+++ b/scripts/Phalcon/Db/Adapter/Pdo/PostgresqlExtended.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+  +------------------------------------------------------------------------+
+  | Phalcon Framework                                                      |
+  +------------------------------------------------------------------------+
+  | Copyright (c) 2011-2017 Phalcon Team (http://www.phalconphp.com)       |
+  +------------------------------------------------------------------------+
+  | This source file is subject to the New BSD License that is bundled     |
+  | with this package in the file LICENSE.txt.                             |
+  |                                                                        |
+  | If you did not receive a copy of the license and are unable to         |
+  | obtain it through the world-wide-web, please send an email             |
+  | to license@phalconphp.com so we can send you a copy immediately.       |
+  +------------------------------------------------------------------------+
+  | Authors: Sergii Svyrydenko <sergey.v.sviridenko@gmail.com>             |
+  |                                                                        |
+  +------------------------------------------------------------------------+
+*/
+
+namespace Phalcon\Db\Adapter\Pdo;
+
+use Phalcon\Db\ReferenceInterface;
+use Phalcon\Db\Reference;
+use Phalcon\Db\Exception;
+use Phalcon\Db;
+
+/**
+ * Phalcon\Db\Dialect\Postgresql
+ *
+ * @package Phalcon\Db\Adapter\Pdo
+ */
+class PostgresqlExtended extends Postgresql
+{
+    /**
+     * Lists table references
+     *
+     * @param string $table
+     * @param string $schema
+     * @return Reference
+     *
+     */
+    public function describeReferences($table, $schema = NULL)
+    {
+		$references = [];
+
+        foreach ($this->fetchAll($this->_dialect->describeReferences($table, $schema),Db::FETCH_NUM) as $reference) {
+            $constraintName = $reference[2];
+            if (!isset($references[$constraintName])) {
+                $referencedSchema  = $reference[3];
+                $referencedTable   = $reference[4];
+                $referenceUpdate   = $reference[6];
+                $referenceDelete   = $reference[7];
+                $columns           = [];
+                $referencedColumns = [];
+            } else {
+                $referencedSchema  = $references[$constraintName]["referencedSchema"];
+                $referencedTable   = $references[$constraintName]["referencedTable"];
+                $columns           = $references[$constraintName]["columns"];
+                $referencedColumns = $references[$constraintName]["referencedColumns"];
+                $referenceUpdate   = $references[$constraintName]["onUpdate"];
+                $referenceDelete   = $references[$constraintName]["onDelete"];
+            }
+
+            $columns[] = $reference[1];
+            $referencedColumns[] = $reference[5];
+
+            $references[$constraintName] = [
+                "referencedSchema"  => $referencedSchema,
+                "referencedTable"   => $referencedTable,
+                "columns"           => $columns,
+                "referencedColumns" => $referencedColumns,
+                "onUpdate"          => $referenceUpdate,
+                "onDelete"          => $referenceDelete
+            ];
+        }
+        
+        $referenceObjects = [];
+
+        foreach ($references as $name => $arrayReference) {
+            $referenceObjects[$name] = new Reference($name, [
+                "referencedSchema"  => $arrayReference["referencedSchema"],
+				"referencedTable"   => $arrayReference["referencedTable"],
+				"columns"           => $arrayReference["columns"],
+				"referencedColumns" => $arrayReference["referencedColumns"],
+				"onUpdate"          => $arrayReference["onUpdate"],
+				"onDelete"          => $arrayReference["onDelete"]
+			]);
+        }
+
+		return $referenceObjects;
+    }
+}

--- a/scripts/Phalcon/Db/Dialect/PostgresqlExtended.php
+++ b/scripts/Phalcon/Db/Dialect/PostgresqlExtended.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+  +------------------------------------------------------------------------+
+  | Phalcon Framework                                                      |
+  +------------------------------------------------------------------------+
+  | Copyright (c) 2011-2017 Phalcon Team (http://www.phalconphp.com)       |
+  +------------------------------------------------------------------------+
+  | This source file is subject to the New BSD License that is bundled     |
+  | with this package in the file LICENSE.txt.                             |
+  |                                                                        |
+  | If you did not receive a copy of the license and are unable to         |
+  | obtain it through the world-wide-web, please send an email             |
+  | to license@phalconphp.com so we can send you a copy immediately.       |
+  +------------------------------------------------------------------------+
+  | Authors: Sergii Svyrydenko <sergey.v.sviridenko@gmail.com>             |
+  |                                                                        |
+  +------------------------------------------------------------------------+
+*/
+
+namespace Phalcon\Db\Dialect;
+
+use Phalcon\Db\ReferenceInterface;
+
+/**
+ * Phalcon\Db\Dialect\MysqlExtended
+ *
+ * @package Phalcon\Db\Dialect
+ */
+class PostgresqlExtended extends Postgresql
+{
+    /**
+     * Generates SQL to query foreign keys on a table
+     *
+     * @param string $table
+     * @param string $schema
+     * @return string
+     */
+    public function describeReferences($table, $schema = NULL)
+    {
+        $sql = "
+            SELECT DISTINCT
+              tc.table_name as TABLE_NAME,
+              kcu.column_name as COLUMN_NAME,
+              tc.constraint_name as CONSTRAINT_NAME,
+              tc.table_catalog as REFERENCED_TABLE_SCHEMA,
+              ccu.table_name AS REFERENCED_TABLE_NAME,
+              ccu.column_name AS REFERENCED_COLUMN_NAME,
+              rc.update_rule AS UPDATE_RULE,
+              rc.delete_rule AS DELETE_RULE
+            FROM information_schema.table_constraints AS tc
+              JOIN information_schema.key_column_usage AS kcu
+                ON tc.constraint_name = kcu.constraint_name
+              JOIN information_schema.constraint_column_usage AS ccu
+                ON ccu.constraint_name = tc.constraint_name
+              JOIN information_schema.referential_constraints rc
+                ON tc.constraint_catalog = rc.constraint_catalog
+                AND tc.constraint_schema = rc.constraint_schema
+                AND tc.constraint_name = rc.constraint_name
+                AND  tc.constraint_type = 'FOREIGN KEY'
+            WHERE constraint_type = 'FOREIGN KEY'
+                AND ";
+
+        if ($schema) {
+            $sql .= "tc.table_schema = '" . $schema . "' AND tc.table_name='" . $table . "'";
+		} else {
+            $sql .= "tc.table_schema = 'public' AND tc.table_name='" . $table . "'";
+		}
+
+        return $sql;
+    }
+}

--- a/scripts/Phalcon/Mvc/Model/Migration.php
+++ b/scripts/Phalcon/Mvc/Model/Migration.php
@@ -35,6 +35,8 @@ use Phalcon\Exception\Db\UnknownColumnTypeException;
 use Phalcon\Version\ItemCollection as VersionCollection;
 use Phalcon\Db\Dialect\MysqlExtended;
 use Phalcon\Db\Adapter\Pdo\MysqlExtended as AdapterMysqlExtended;
+use Phalcon\Db\Dialect\PostgresqlExtended;
+use Phalcon\Db\Adapter\Pdo\PostgresqlExtended as AdapterPostgresqlExtended;
 
 /**
  * Phalcon\Mvc\Model\Migration
@@ -99,6 +101,9 @@ class Migration
          */
         if ($database->adapter == 'Mysql') {
             $adapter = AdapterMysqlExtended::class;
+        } elseif ($database->adapter == 'Postgresql') { //Added describeReferences() method for Postgresql adapter
+            $adapter = AdapterPostgresqlExtended::class;
+            print_r($adapter);die;
         } else {
             $adapter = '\\Phalcon\\Db\\Adapter\\Pdo\\'.$database->adapter;
         }
@@ -115,6 +120,10 @@ class Migration
         //Connection custom dialect Dialect/MysqlExtended
         if ($database->adapter == 'Mysql') {
             self::$_connection->setDialect(new MysqlExtended);
+        }
+        //Connection custom dialect Dialect/PostgresqlExtended
+        if ($database->adapter == 'Postgresql') {
+            self::$_connection->setDialect(new PostgresqlExtended);
         }
 
         if (Migrations::isConsole()) {


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:
Added describeReferences() methods in adapter and dialect for postgresql DB

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
