### PR TITLE
* Fix creating table to track migration versions in the db

### DIFF
--- a/scripts/Phalcon/Migrations.php
+++ b/scripts/Phalcon/Migrations.php
@@ -430,7 +430,8 @@ class Migrations
                         new Column(
                             'end_time',
                             [
-                                'type' => 'TIMESTAMP NOT NULL DEFAULT NOW()',
+                                'type' => Column::TYPE_TIMESTAMP,
+                                'notNull' => true,
                             ]
                         )
                     ],


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:
This fixes defining the 'end_time' column properly when creating the table to track migration versions.

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
