### PR TITLE
Added document root default to serve command

### DIFF
--- a/scripts/Phalcon/Commands/Builtin/Serve.php
+++ b/scripts/Phalcon/Commands/Builtin/Serve.php
@@ -37,14 +37,16 @@ use Phalcon\Bootstrap;
  */
 class Serve extends Command
 {
-    const DEFAULT_HOSTNAME  = '0.0.0.0';
-    const DEFAULT_PORT      = '8080';
-    const DEFAULT_BASE_PATH = 'public/index.php';
+    const DEFAULT_HOSTNAME      = '0.0.0.0';
+    const DEFAULT_PORT          = '8000';
+    const DEFAULT_BASE_PATH     = '.htrouter.php';
+    const DEFAULT_DOCUMENT_ROOT = 'public';
 
-    protected $_hostname = '';
-    protected $_port = '';
-    protected $_base_path = '';
-    protected $_config = '';
+    protected $_hostname =      '';
+    protected $_port =          '';
+    protected $_base_path =     '';
+    protected $_document_root = '';
+    protected $_config =        '';
 
     /**
      * {@inheritdoc}
@@ -57,6 +59,7 @@ class Serve extends Command
             'hostname=s'        => 'Server Hostname [default='.self::DEFAULT_HOSTNAME.']',
             'port=s'            => 'Server Port [default='.self::DEFAULT_PORT.']',
             'basepath=s'        => 'Project entry-point [default='.self::DEFAULT_BASE_PATH.']',
+            'rootpath=s'        => 'Document Root (public assets) [default='.self::DEFAULT_DOCUMENT_ROOT.']',
             'config=s'          => 'Server configuration ini [optional]',
             'help'              => 'Shows this help [optional]',
         ];
@@ -86,10 +89,11 @@ class Serve extends Command
      */
     public function prepareOptions()
     {
-        $this->_hostname  = $this->getOption(['hostname', 1], null, self::DEFAULT_HOSTNAME);
-        $this->_port      = $this->getOption(['port',     2], null, self::DEFAULT_PORT);
-        $this->_base_path = $this->getOption(['basepath', 3], null, self::DEFAULT_BASE_PATH);
-        $this->_config    = $this->customConfig($this->getOption(['config']));
+        $this->_hostname      = $this->getOption(['hostname', 1], null, self::DEFAULT_HOSTNAME);
+        $this->_port          = $this->getOption(['port',     2], null, self::DEFAULT_PORT);
+        $this->_base_path     = $this->getOption(['basepath', 3], null, self::DEFAULT_BASE_PATH);
+        $this->_document_root = $this->getOption(['rootpath', 4], null, self::DEFAULT_DOCUMENT_ROOT);
+        $this->_config        = $this->customConfig($this->getOption(['config']));
     }
 
     /**
@@ -102,7 +106,8 @@ class Serve extends Command
         print Color::head('Preparing Development Server') . PHP_EOL;
         print Color::colorize("  Host: $this->_hostname", Color::FG_GREEN) . PHP_EOL;
         print Color::colorize("  Port: $this->_port", Color::FG_GREEN) . PHP_EOL;
-        print Color::colorize("  Base: $$this->_base_path", Color::FG_GREEN) . PHP_EOL;
+        print Color::colorize("  Base: $this->_base_path", Color::FG_GREEN) . PHP_EOL;
+        print Color::colorize("  Document Root: $this->_document_root", Color::FG_GREEN) . PHP_EOL;
         if($this->_config != null) {
             print Color::colorize("   ini: $$this->_config", Color::FG_GREEN) . PHP_EOL;
         }
@@ -121,10 +126,11 @@ class Serve extends Command
         $this->prepareOptions();
         $this->printServerDetails();
 
-        return sprintf('%s -S %s:%s %s %s',
+        return sprintf('%s -S %s:%s -t %s %s %s',
             $binary_path,
             $this->_hostname,
             $this->_port,
+            $this->_document_root,
             $this->_base_path,
             $this->_config
         );
@@ -165,11 +171,12 @@ class Serve extends Command
         print Color::colorize('  Launch the built-in PHP development server') . PHP_EOL . PHP_EOL;
 
         print Color::head('Usage:') . PHP_EOL;
-        print Color::colorize('  serve [hostname] [port]', Color::FG_GREEN) . PHP_EOL . PHP_EOL;
+        print Color::colorize('  serve [hostname='.self::DEFAULT_HOSTNAME.
+            '] [port='.self::DEFAULT_PORT.
+            '] [entrypoint='.self::DEFAULT_BASE_PATH.
+            '] [document-root='.self::DEFAULT_DOCUMENT_ROOT.']', Color::FG_GREEN) . PHP_EOL . PHP_EOL;
 
         print Color::head('Arguments:') . PHP_EOL;
-        print Color::colorize('  config', Color::FG_GREEN);
-        print Color::colorize("\tSpecify a custom php.ini") . PHP_EOL . PHP_EOL;
         print Color::colorize('  help', Color::FG_GREEN);
         print Color::colorize("\t\tShows this help text") . PHP_EOL . PHP_EOL;
 
@@ -214,6 +221,16 @@ class Serve extends Command
     public function getBasePath()
     {
         return $this->_base_path;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function getDocumentRoot()
+    {
+        return $this->_document_root;
     }
 
     /**

--- a/tests/unit/ServeTest.php
+++ b/tests/unit/ServeTest.php
@@ -41,7 +41,7 @@ class ServeTest extends \Codeception\Test\Unit
     }
 
     /**
-     * Verify that is no arguments are passed via the command line
+     * Verify that if no arguments are passed via the command line
      * this will provide a valid default configuration
      *
      * @author Paul Scarrone <paul@savvysoftworks.com>
@@ -52,13 +52,14 @@ class ServeTest extends \Codeception\Test\Unit
         $this->command->parseParameters([], []);
         $this->command->prepareOptions();
         $this->assertEquals('0.0.0.0', $this->command->getHostname());
-        $this->assertEquals('8080', $this->command->getPort());
-        $this->assertEquals('public/index.php', $this->command->getBasePath());
+        $this->assertEquals('8000', $this->command->getPort());
+        $this->assertEquals('.htrouter.php', $this->command->getBasePath());
+        $this->assertEquals('public', $this->command->getDocumentRoot());
         $this->assertEmpty($this->command->getConfigPath());
     }
 
     /**
-     * Verify that is no arguments are passed via the command line
+     * Verify that if no arguments are passed via the command line
      * this will provide a valid default configuration
      *
      * @author Paul Scarrone <paul@savvysoftworks.com>
@@ -68,11 +69,11 @@ class ServeTest extends \Codeception\Test\Unit
         $_SERVER['argv'] = ['',''];
         $this->command->parseParameters([], []);
         $command = $this->command->shellCommand();
-        $this->assertContains('php -S 0.0.0.0:8080 public/index.php', $command);
+        $this->assertContains('php -S 0.0.0.0:8000 -t public .htrouter.php', $command);
     }
 
     /**
-     * Verify that is no arguments are passed via the command line
+     * Verify that if no arguments are passed via the command line
      * this will provide a valid default configuration when only the
      * hostname is provided
      *
@@ -84,13 +85,14 @@ class ServeTest extends \Codeception\Test\Unit
         $this->command->parseParameters([], []);
         $this->command->prepareOptions();
         $this->assertEquals('localhost', $this->command->getHostname());
-        $this->assertEquals('8080', $this->command->getPort());
-        $this->assertEquals('public/index.php', $this->command->getBasePath());
+        $this->assertEquals('8000', $this->command->getPort());
+        $this->assertEquals('.htrouter.php', $this->command->getBasePath());
+        $this->assertEquals('public', $this->command->getDocumentRoot());
         $this->assertEmpty($this->command->getConfigPath());
     }
 
     /**
-     * Verify that is no arguments are passed via the command line
+     * Verify that if no arguments are passed via the command line
      * this will provide a valid default configuration when only the
      * hostname is provided
      *
@@ -101,11 +103,11 @@ class ServeTest extends \Codeception\Test\Unit
         $_SERVER['argv'] = ['','', 'localhost'];
         $this->command->parseParameters([], []);
         $command = $this->command->shellCommand();
-        $this->assertContains('php -S localhost:8080 public/index.php', $command);
+        $this->assertContains('php -S localhost:8000 -t public .htrouter.php', $command);
     }
 
     /**
-     * Verify that is no arguments are passed via the command line
+     * Verify that if no arguments are passed via the command line
      * this will provide a valid default configuration when only the
      * port is provided
      *
@@ -118,12 +120,13 @@ class ServeTest extends \Codeception\Test\Unit
         $this->command->prepareOptions();
         $this->assertEquals('0.0.0.0', $this->command->getHostname());
         $this->assertEquals('1111', $this->command->getPort());
-        $this->assertEquals('public/index.php', $this->command->getBasePath());
+        $this->assertEquals('.htrouter.php', $this->command->getBasePath());
+        $this->assertEquals('public', $this->command->getDocumentRoot());
         $this->assertEmpty($this->command->getConfigPath());
     }
 
     /**
-     * Verify that is no arguments are passed via the command line
+     * Verify that if no arguments are passed via the command line
      * this will provide a valid default configuration when only the
      * port is provided
      *
@@ -134,11 +137,11 @@ class ServeTest extends \Codeception\Test\Unit
         $_SERVER['argv'] = ['','', null, 1111];
         $this->command->parseParameters([], []);
         $command = $this->command->shellCommand();
-        $this->assertContains('php -S 0.0.0.0:1111 public/index.php', $command);
+        $this->assertContains('php -S 0.0.0.0:1111 -t public .htrouter.php', $command);
     }
 
     /**
-     * Verify that is no arguments are passed via the command line
+     * Verify that if no arguments are passed via the command line
      * this will provide a valid default configuration when only the
      * basepath is provided
      *
@@ -150,13 +153,14 @@ class ServeTest extends \Codeception\Test\Unit
         $this->command->parseParameters([], []);
         $this->command->prepareOptions();
         $this->assertEquals('0.0.0.0', $this->command->getHostname());
-        $this->assertEquals('8080', $this->command->getPort());
+        $this->assertEquals('8000', $this->command->getPort());
         $this->assertEquals('/root/bin.php', $this->command->getBasePath());
+        $this->assertEquals('public', $this->command->getDocumentRoot());
         $this->assertEmpty($this->command->getConfigPath());
     }
 
     /**
-     * Verify that is no arguments are passed via the command line
+     * Verify that if no arguments are passed via the command line
      * this will provide a valid default configuration when only the
      * basepath is provided
      *
@@ -167,11 +171,45 @@ class ServeTest extends \Codeception\Test\Unit
         $_SERVER['argv'] = ['','', null, null, '/root/bin.php'];
         $this->command->parseParameters([], []);
         $command = $this->command->shellCommand();
-        $this->assertContains('php -S 0.0.0.0:8080 /root/bin.php', $command);
+        $this->assertContains('php -S 0.0.0.0:8000 -t public /root/bin.php', $command);
     }
 
     /**
-     * Verify that is no arguments are passed via the command line
+     * Verify that if no arguments are passed via the command line
+     * this will provide a valid default configuration when only the
+     * rootpath is provided
+     *
+     * @author Paul Scarrone <paul@savvysoftworks.com>
+     */
+    public function testDefaultValuesWithDocumentRootOnly()
+    {
+        $_SERVER['argv'] = ['','', null, null, null, 'not_too_public'];
+        $this->command->parseParameters([], []);
+        $this->command->prepareOptions();
+        $this->assertEquals('0.0.0.0', $this->command->getHostname());
+        $this->assertEquals('8000', $this->command->getPort());
+        $this->assertEquals('.htrouter.php', $this->command->getBasePath());
+        $this->assertEquals('not_too_public', $this->command->getDocumentRoot());
+        $this->assertEmpty($this->command->getConfigPath());
+    }
+
+    /**
+     * Verify that if no arguments are passed via the command line
+     * this will provide a valid default configuration when only the
+     * rootpath is provided
+     *
+     * @author Paul Scarrone <paul@savvysoftworks.com>
+     */
+    public function testGeneratedCommandWithDocumentRootOnly()
+    {
+        $_SERVER['argv'] = ['','', null, null, null, 'not_too_public'];
+        $this->command->parseParameters([], []);
+        $command = $this->command->shellCommand();
+        $this->assertContains('php -S 0.0.0.0:8000 -t not_too_public .htrouter.php', $command);
+    }
+
+    /**
+     * Verify that if no arguments are passed via the command line
      * this will provide a valid default configuration when only the
      * config is provided
      *
@@ -183,13 +221,14 @@ class ServeTest extends \Codeception\Test\Unit
         $this->command->parseParameters([], []);
         $this->command->prepareOptions();
         $this->assertEquals('0.0.0.0', $this->command->getHostname());
-        $this->assertEquals('8080', $this->command->getPort());
-        $this->assertEquals('public/index.php', $this->command->getBasePath());
+        $this->assertEquals('8000', $this->command->getPort());
+        $this->assertEquals('.htrouter.php', $this->command->getBasePath());
+        $this->assertEquals('public', $this->command->getDocumentRoot());
         $this->assertEquals('-c awesome.ini', $this->command->getConfigPath());
     }
 
     /**
-     * Verify that is no arguments are passed via the command line
+     * Verify that if no arguments are passed via the command line
      * this will provide a valid default configuration when only the
      * config is provided
      *
@@ -200,6 +239,6 @@ class ServeTest extends \Codeception\Test\Unit
         $_SERVER['argv'] = ['','', null, null, null, '--config=awesome.ini'];
         $this->command->parseParameters([], []);
         $command = $this->command->shellCommand();
-        $this->assertContains('php -S 0.0.0.0:8080 public/index.php -c awesome.ini', $command);
+        $this->assertContains('php -S 0.0.0.0:8000 -t public .htrouter.php -c awesome.ini', $command);
     }
 }


### PR DESCRIPTION
Hello!

* Type: **bug fix**
* Link to issue: #1041 | https://github.com/phalcon/docs/pull/1135

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR

Small description of change:
After reviewing https://github.com/phalcon/docs/blob/3.2/en/webserver-setup.md I realized I missed the required document root from the built-in php server command along with a need for the default entrypoint for devtools to be the `.htrouter.php` so this command can work out of the box as `phalcon serve` without the need for any additional arguments.

I have updated the tests and cleared a typo in the commands output. No additional behavior was changed just the addition of a new argument and improved documentation.

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
