### PR TITLE
Make phalcon self-healing when executing an external false command when .phalcon folder is missing

### DIFF
--- a/phalcon.php
+++ b/phalcon.php
@@ -37,6 +37,7 @@ use Phalcon\Commands\Builtin\Controller;
 use Phalcon\Commands\Builtin\Serve;
 use Phalcon\Commands\Builtin\Console;
 use Phalcon\Exception as PhalconException;
+use Phalcon\Commands\DotPhalconMissingException;
 use Phalcon\Events\Manager as EventsManager;
 
 try {
@@ -73,6 +74,13 @@ try {
     }
 
     $script->run();
+} catch (DotPhalconMissingException $e) {
+    fwrite(STDERR, Color::info($e->getMessage() . " " . $e->scanPathMessage()));
+    if ($e->promptResolution()) {
+        $script->run();
+    } else {
+        exit(1);
+    }
 } catch (PhalconException $e) {
     fwrite(STDERR, Color::error($e->getMessage()) . PHP_EOL);
     exit(1);

--- a/scripts/Phalcon/Commands/CommandsListener.php
+++ b/scripts/Phalcon/Commands/CommandsListener.php
@@ -36,7 +36,7 @@ class CommandsListener
      * @param Command $command
      *
      * @return bool
-     * @throws CommandsException
+     * @throws DotPhalconMissingException
      */
     public function beforeCommand(Event $event, Command $command)
     {
@@ -55,7 +55,7 @@ class CommandsListener
         if ($command->canBeExternal() == false) {
             $path = $command->getOption('directory');
             if (!file_exists($path.'.phalcon') || !is_dir($path.'.phalcon')) {
-                throw new CommandsException('This command should be invoked inside a Phalcon project directory.');
+                throw new DotPhalconMissingException();
             }
         }
 

--- a/scripts/Phalcon/Commands/DotPhalconMissingException.php
+++ b/scripts/Phalcon/Commands/DotPhalconMissingException.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+  +------------------------------------------------------------------------+
+  | Phalcon Developer Tools                                                |
+  +------------------------------------------------------------------------+
+  | Copyright (c) 2011-2017 Phalcon Team (https://www.phalconphp.com)      |
+  +------------------------------------------------------------------------+
+  | This source file is subject to the New BSD License that is bundled     |
+  | with this package in the file LICENSE.txt.                             |
+  |                                                                        |
+  | If you did not receive a copy of the license and are unable to         |
+  | obtain it through the world-wide-web, please send an email             |
+  | to license@phalconphp.com so we can send you a copy immediately.       |
+  +------------------------------------------------------------------------+
+  | Authors: Paul Scarrone <paul@savvysoftworks.com>                       |
+  +------------------------------------------------------------------------+
+*/
+
+namespace Phalcon\Commands;
+
+use Phalcon\Exception;
+use Phalcon\Generator\Stub;
+use Phalcon\Script\Color;
+
+/**
+ * .phalcon is missing Exception
+ *  This is thrown when a CLI command is run without a .phalcon file
+ *  In the CWD
+ * @package Phalcon\Commands
+ */
+class DotPhalconMissingException extends CommandsException
+{
+    const DEFAULT_MESSAGE = "This command must be run inside a Phalcon project with a .phalcon directory.";
+    const RESOLUTION_PROMPT = "Shall I create the .phalcon directory now? (y/n)";
+
+    public function __construct (string $message = self::DEFAULT_MESSAGE , int $code = 0)
+    {
+        $this->message = $message;
+        $this->code = $code;
+    }
+
+    public function scanPathMessage()
+    {
+        return "One was not found at " . getcwd();
+    }
+
+    public function promptResolution() {
+        fwrite(STDOUT, Color::info(self::RESOLUTION_PROMPT));
+        $handle = fopen ("php://stdin","r");
+        $line = fgets($handle);
+        if(trim($line) != 'y'){
+            echo "ABORTING!\n";
+            return false;
+        }
+        fclose($handle);
+        echo "\n";
+        echo "Retrying command...\n";
+        $this->resolve();
+        return true;
+    }
+
+    public function resolve() {
+        return mkdir(getcwd() . "/.phalcon");
+    }
+}

--- a/scripts/Phalcon/Commands/DotPhalconMissingException.php
+++ b/scripts/Phalcon/Commands/DotPhalconMissingException.php
@@ -29,7 +29,7 @@ use Phalcon\Script\Color;
  *  In the CWD
  * @package Phalcon\Commands
  */
-class DotPhalconMissingException extends CommandsException
+class DotPhalconMissingException extends CommandsException implements iSelfHealingException
 {
     const DEFAULT_MESSAGE = "This command must be run inside a Phalcon project with a .phalcon directory.";
     const RESOLUTION_PROMPT = "Shall I create the .phalcon directory now? (y/n)";

--- a/scripts/Phalcon/Commands/iSelfHealingException.php
+++ b/scripts/Phalcon/Commands/iSelfHealingException.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+  +------------------------------------------------------------------------+
+  | Phalcon Developer Tools                                                |
+  +------------------------------------------------------------------------+
+  | Copyright (c) 2011-2017 Phalcon Team (https://www.phalconphp.com)      |
+  +------------------------------------------------------------------------+
+  | This source file is subject to the New BSD License that is bundled     |
+  | with this package in the file LICENSE.txt.                             |
+  |                                                                        |
+  | If you did not receive a copy of the license and are unable to         |
+  | obtain it through the world-wide-web, please send an email             |
+  | to license@phalconphp.com so we can send you a copy immediately.       |
+  +------------------------------------------------------------------------+
+  | Authors: Paul Scarrone <paul@savvysoftworks.com>                       |
+  +------------------------------------------------------------------------+
+*/
+
+namespace Phalcon\Commands;
+
+interface iSelfHealingException
+{
+    public function promptResolution();
+    public function resolve();
+}


### PR DESCRIPTION
Hello!

* Type: **new feature**
* Link to issue: #1054

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:

When the exception for a missing .phalcon folder is raised the user is prompted and the missing folder is created automatically. Once the folder is created the command is re-executed.

I have added an interface for "Self-Healing Exceptions" so this can be propagated to other locations where cli execution stops but could be resolved.

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md

<img width="997" alt="screen shot 2017-07-23 at 10 20 32 pm" src="https://user-images.githubusercontent.com/159591/28505857-324d560e-6ff5-11e7-9cc9-6e0ac5a8180e.png">
