### PR TITLE
Added camelize option for all-model command

### DIFF
--- a/scripts/Phalcon/Builder/AllModels.php
+++ b/scripts/Phalcon/Builder/AllModels.php
@@ -208,7 +208,8 @@ class AllModels extends Component
                     'modelsDir' => $this->options->get('modelsDir'),
                     'mapColumn' => $mapColumn,
                     'abstract' => $this->options->get('abstract'),
-                    'referenceList' => $referenceList
+                    'referenceList' => $referenceList,
+                    'camelize' => $this->options->get('camelize')
                 ]);
 
                 $modelBuilder->build();

--- a/scripts/Phalcon/Commands/Builtin/AllModels.php
+++ b/scripts/Phalcon/Commands/Builtin/AllModels.php
@@ -50,6 +50,7 @@ class AllModels extends Command
             'namespace=s' => "Model's namespace [optional]",
             'extends=s'   => 'Models extends [optional]',
             'force'       => 'Force script to rewrite all the models [optional]',
+            'camelize'    => 'Properties is in camelCase [optional]',
             'get-set'     => 'Attributes will be protected and have setters/getters [optional]',
             'doc'         => 'Helps to improve code completion on IDEs [optional]',
             'relations'   => 'Possible relations defined according to convention [optional]',
@@ -126,7 +127,8 @@ class AllModels extends Command
             'genDocMethods' => $this->isReceivedOption('doc'),
             'modelsDir' => $modelsDir,
             'mapColumn' => $this->isReceivedOption('mapcolumn'),
-            'abstract' => $this->isReceivedOption('abstract')
+            'abstract' => $this->isReceivedOption('abstract'),
+            'camelize' => $this->isReceivedOption('camelize'),
         ]);
 
         $modelBuilder->build();


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #913

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:
added `camelize` option for `all-models` command. It works like creating model for one table that using this option

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
