### PR TITLE
Bug fix controller when use getters and setters

### DIFF
--- a/scripts/Phalcon/Builder/Scaffold.php
+++ b/scripts/Phalcon/Builder/Scaffold.php
@@ -520,6 +520,12 @@ class Scaffold extends Component
         $attributes = $this->options->get('attributes');
 
         $code = str_replace('$pkVar$', '$' . $attributes[0], $code);
+
+        if ($this->options->get('genSettersGetters')) {
+            $code = str_replace('$pkGet$', 'get'.Text::camelize($attributes[0]).'()', $code);
+        } else {
+            $code = str_replace('$pkGet$', $attributes[0], $code);
+        }
         $code = str_replace('$pk$', $attributes[0], $code);
 
         if ($this->isConsole()) {

--- a/templates/scaffold/no-forms/Controller.php
+++ b/templates/scaffold/no-forms/Controller.php
@@ -83,7 +83,7 @@ class $className$Controller extends ControllerBase
                 return;
             }
 
-            $this->view->$pk$ = $singularVar$->$pk$;
+            $this->view->$pk$ = $singularVar$->$pkGet$;
 
             $assignTagDefaults$
         }
@@ -168,7 +168,7 @@ class $className$Controller extends ControllerBase
             $this->dispatcher->forward([
                 'controller' => "$plural$",
                 'action' => 'edit',
-                'params' => [$singularVar$->$pk$]
+                'params' => [$singularVar$->$pkGet$]
             ]);
 
             return;


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #203 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:
Fixed problem in controller when using command `phalcon scaffold --get-set --table-name=foo-bar`. Generated controller contains without `get` methods.

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
