### PR TITLE
deleted unused param when gereneration all-model

### DIFF
--- a/scripts/Phalcon/Commands/Builtin/AllModels.php
+++ b/scripts/Phalcon/Commands/Builtin/AllModels.php
@@ -55,7 +55,6 @@ class AllModels extends Command
             'doc'         => 'Helps to improve code completion on IDEs [optional]',
             'relations'   => 'Possible relations defined according to convention [optional]',
             'fk'          => 'Define any virtual foreign keys [optional]',
-            'validations' => 'Define possible domain validation according to conventions',
             'directory=s' => 'Base path on which project will be created [optional]',
             'mapcolumn'   => 'Get some code for map columns [optional]',
             'abstract'    => 'Abstract Model [optional]',


### PR DESCRIPTION
Hello!

* Type: code quality
* Link to issue: #234

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:
models created with commands `all-models` and `model` are same. Option `validations` in `all-models` command is unused.

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
