### PR TITLE
Fixed referencedSchema in migration for Postgresql

### DIFF
--- a/scripts/Phalcon/Db/Dialect/PostgresqlExtended.php
+++ b/scripts/Phalcon/Db/Dialect/PostgresqlExtended.php
@@ -43,7 +43,7 @@ class PostgresqlExtended extends Postgresql
               tc.table_name as TABLE_NAME,
               kcu.column_name as COLUMN_NAME,
               tc.constraint_name as CONSTRAINT_NAME,
-              tc.table_catalog as REFERENCED_TABLE_SCHEMA,
+              tc.table_schema as REFERENCED_TABLE_SCHEMA,
               ccu.table_name AS REFERENCED_TABLE_NAME,
               ccu.column_name AS REFERENCED_COLUMN_NAME,
               rc.update_rule AS UPDATE_RULE,

--- a/scripts/Phalcon/Mvc/Model/Migration.php
+++ b/scripts/Phalcon/Mvc/Model/Migration.php
@@ -355,6 +355,7 @@ class Migration
 
             $referenceDefinition = [];
             $referenceDefinition[] = "'referencedTable' => '".$dbReference->getReferencedTable()."'";
+            $referenceDefinition[] = "'referencedSchema' => '".$dbReference->getReferencedSchema()."'";
             $referenceDefinition[] = "'columns' => [".join(",", array_unique($columns))."]";
             $referenceDefinition[] = "'referencedColumns' => [".join(",", array_unique($referencedColumns))."]";
             $referenceDefinition[] = "'onUpdate' => '".$dbReference->getOnUpdate()."'";
@@ -693,6 +694,7 @@ class Migration
                 foreach ($activeReferences as $activeReference) {
                     $localReferences[$activeReference->getName()] = [
                         'referencedTable'   => $activeReference->getReferencedTable(),
+                        "referencedSchema"  => $activeReference->getReferencedSchema(),
                         'columns'           => $activeReference->getColumns(),
                         'referencedColumns' => $activeReference->getReferencedColumns(),
                     ];

--- a/tests/_support/Helper/Db/Dialect/PostgresqlTrait.php
+++ b/tests/_support/Helper/Db/Dialect/PostgresqlTrait.php
@@ -41,7 +41,7 @@ trait PostgresqlTrait
         return
             ['test_describereferences' => new Reference('test_describereferences', [
                 'referencedTable'   => 'foreign_key_parent',
-                'referencedSchema' => 'devtools',
+                'referencedSchema' => 'public',
                 'columns'           => ['child_int'],
                 'referencedColumns' => ['refer_int'],
                 'onUpdate'          => 'CASCADE',


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #238

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:
Fixed `referencedSchema` and added it when migration generating

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
