### PR TITLE
Update CommandsListener.php

### DIFF
--- a/scripts/Phalcon/Commands/CommandsListener.php
+++ b/scripts/Phalcon/Commands/CommandsListener.php
@@ -54,7 +54,7 @@ class CommandsListener
 
         if ($command->canBeExternal() == false) {
             $path = $command->getOption('directory');
-            if (!file_exists($path.'.phalcon') || !is_dir($path.'.phalcon')) {
+            if (is_dir($path) && ( !file_exists($path.'.phalcon') || !is_dir($path.'.phalcon' )) ) {
                 throw new DotPhalconMissingException();
             }
         }


### PR DESCRIPTION
when use devtools create all-models command and under module's project.

always get this error exception.

the problem was $command->getOption('directory') == null;

fix this bug.

```
Info: This command must be run inside a Phalcon project with a .phalcon directory. One was not found at /Users/laoliu/Development/www/ProjectName


  Info: Shall I create the .phalcon directory now? (y/n)
```

Hello!

* Type: bug fix
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [*] I have read and understood the [Contributing Guidelines][:contrib:]
- [*] I have checked that another pull request for this purpose does not exist
- [*] I wrote some tests for this PR

Small description of change:

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
