### PR TITLE
Changed title of option  all-models for folder where models are located

### DIFF
--- a/scripts/Phalcon/Commands/Builtin/AllModels.php
+++ b/scripts/Phalcon/Commands/Builtin/AllModels.php
@@ -45,7 +45,6 @@ class AllModels extends Command
     {
         return [
             'config=s'    => 'Configuration file [optional]',
-            'models=s'    => 'Models directory [optional]',
             'schema=s'    => 'Name of the schema. [optional]',
             'namespace=s' => "Model's namespace [optional]",
             'extends=s'   => 'Models extends [optional]',
@@ -56,6 +55,7 @@ class AllModels extends Command
             'relations'   => 'Possible relations defined according to convention [optional]',
             'fk'          => 'Define any virtual foreign keys [optional]',
             'directory=s' => 'Base path on which project will be created [optional]',
+            'output=s'    => 'Folder where models are located [optional]',
             'mapcolumn'   => 'Get some code for map columns [optional]',
             'abstract'    => 'Abstract Model [optional]',
             'help'        => 'Shows this help [optional]',
@@ -100,13 +100,13 @@ class AllModels extends Command
             $config = $this->path->getConfig();
         }
 
-        if (!$this->isReceivedOption('models')) {
+        if (!$this->isReceivedOption('output')) {
             if (!isset($config->application->modelsDir)) {
                 throw new CommandsException("Builder doesn't know where is the models directory.");
             }
             $modelsDir = rtrim($config->application->modelsDir, '\\/') . DIRECTORY_SEPARATOR;
         } else {
-            $modelsDir = $this->getOption('models');
+            $modelsDir = $this->getOption('output');
         }
 
         if (false == $this->path->isAbsolutePath($modelsDir)) {


### PR DESCRIPTION
Hello!

* Type: code quality
* Link to issue: -

**In raising this pull request, I confirm the following :**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:
Option `models` for command `all-models` isn't obviously and should be like for option for `model`.

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
