### PR TITLE
Fixed query for deleting row from migration log table

### DIFF
--- a/scripts/Phalcon/Migrations.php
+++ b/scripts/Phalcon/Migrations.php
@@ -546,7 +546,7 @@ class Migrations
         if (isset($options['migrationsInDb']) && (bool)$options['migrationsInDb']) {
             /** @var AdapterInterface $connection */
             $connection = self::$_storage;
-            $connection->execute('DELETE FROM '. self::MIGRATION_LOG_TABLE .' WHERE version=\'' . $version . '\' LIMIT 1');
+            $connection->execute('DELETE FROM '. self::MIGRATION_LOG_TABLE .' WHERE version=\'' . $version . '\'');
         } else {
             $currentVersions = self::getCompletedVersions($options);
             unset($currentVersions[(string)$version]);


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #1002

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:
Changed query for deleting row from migration log table, because for PostgreSQL `LIMIT` doesn't work.

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
