### PR TITLE
Fixed generated namespace when model generating with namespace

### DIFF
--- a/scripts/Phalcon/Builder/Model.php
+++ b/scripts/Phalcon/Builder/Model.php
@@ -273,7 +273,7 @@ class Model extends Component
         foreach ($db->describeReferences($this->options->get('name'), $schema) as $reference) {
             $entityNamespace = '';
             if ($this->options->contains('namespace')) {
-                $entityNamespace = $this->options->get('namespace')."\\";
+                $entityNamespace = $this->options->get('namespace');
             }
 
             $refColumns = $reference->getReferencedColumns();


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: -

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:
When model is generating with set namespace `phalcon model testing_child --namespace="FOO\Bar" --extends="foobar"`. Model has namespace `FOO\Bar\\TestingParent` in `belongsTo()`

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
