### PR TITLE
Added option template-engine for project command

### DIFF
--- a/scripts/Phalcon/Builder/Project/Micro.php
+++ b/scripts/Phalcon/Builder/Project/Micro.php
@@ -86,12 +86,14 @@ class Micro extends ProjectBuilder
      */
     private function createIndexViewFiles()
     {
-        $getFile = $this->options->get('templatePath') . '/project/micro/views/index.phtml';
-        $putFile = $this->options->get('projectPath').'app/views/index.phtml';
+        $engine = $this->options->get('templateEngine') == 'volt' ? 'volt' : 'phtml';
+
+        $getFile = $this->options->get('templatePath') . '/project/micro/views/index.' . $engine;
+        $putFile = $this->options->get('projectPath').'app/views/index.' . $engine;
         $this->generateFile($getFile, $putFile);
 
-        $getFile = $this->options->get('templatePath') . '/project/micro/views/404.phtml';
-        $putFile = $this->options->get('projectPath').'app/views/404.phtml';
+        $getFile = $this->options->get('templatePath') . '/project/micro/views/404.' . $engine;
+        $putFile = $this->options->get('projectPath').'app/views/404.' . $engine;
         $this->generateFile($getFile, $putFile);
 
         return $this;

--- a/scripts/Phalcon/Builder/Project/Modules.php
+++ b/scripts/Phalcon/Builder/Project/Modules.php
@@ -147,12 +147,14 @@ class Modules extends ProjectBuilder
      */
     private function createIndexViewFiles()
     {
-        $getFile = $this->options->get('templatePath') . '/project/modules/views/index.volt';
-        $putFile = $this->options->get('projectPath') . 'app/modules/frontend/views/index.volt';
+        $engine = $this->options->get('templateEngine') == 'volt' ? 'volt' : 'phtml';
+
+        $getFile = $this->options->get('templatePath') . '/project/modules/views/index.' . $engine;
+        $putFile = $this->options->get('projectPath') . 'app/modules/frontend/views/index.' . $engine;
         $this->generateFile($getFile, $putFile);
 
-        $getFile = $this->options->get('templatePath') . '/project/modules/views/index/index.volt';
-        $putFile = $this->options->get('projectPath') . 'app/modules/frontend/views/index/index.volt';
+        $getFile = $this->options->get('templatePath') . '/project/modules/views/index/index.' . $engine;
+        $putFile = $this->options->get('projectPath') . 'app/modules/frontend/views/index/index.' . $engine;
         $this->generateFile($getFile, $putFile);
 
         return $this;

--- a/scripts/Phalcon/Builder/Project/Simple.php
+++ b/scripts/Phalcon/Builder/Project/Simple.php
@@ -116,12 +116,14 @@ class Simple extends ProjectBuilder
      */
     private function createIndexViewFiles()
     {
-        $getFile = $this->options->get('templatePath') . '/project/simple/views/index.volt';
-        $putFile = $this->options->get('projectPath').'app/views/index.volt';
+        $engine = $this->options->get('templateEngine') == 'volt' ? 'volt' : 'phtml';
+
+        $getFile = $this->options->get('templatePath') . '/project/simple/views/index.' . $engine;
+        $putFile = $this->options->get('projectPath').'app/views/index.' . $engine;
         $this->generateFile($getFile, $putFile);
 
-        $getFile = $this->options->get('templatePath') . '/project/simple/views/index/index.volt';
-        $putFile = $this->options->get('projectPath').'app/views/index/index.volt';
+        $getFile = $this->options->get('templatePath') . '/project/simple/views/index/index.' . $engine;
+        $putFile = $this->options->get('projectPath').'app/views/index/index.' . $engine;
         $this->generateFile($getFile, $putFile);
 
         return $this;

--- a/scripts/Phalcon/Commands/Builtin/Project.php
+++ b/scripts/Phalcon/Commands/Builtin/Project.php
@@ -42,13 +42,14 @@ class Project extends Command
     {
         return [
             'name=s'            => 'Name of the new project',
-            'enable-webtools' => 'Determines if webtools should be enabled [optional]',
-            'directory=s'     => 'Base path on which project will be created [optional]',
-            'type=s'          => 'Type of the application to be generated (cli, micro, simple, modules)',
-            'template-path=s' => 'Specify a template path [optional]',
-            'use-config-ini'  => 'Use a ini file as configuration file [optional]',
-            'trace'           => 'Shows the trace of the framework in case of exception [optional]',
-            'help'            => 'Shows this help [optional]',
+            'enable-webtools'   => 'Determines if webtools should be enabled [optional]',
+            'directory=s'       => 'Base path on which project will be created [optional]',
+            'type=s'            => 'Type of the application to be generated (cli, micro, simple, modules)',
+            'template-path=s'   => 'Specify a template path [optional]',
+            'template-engine=s' => 'Define the template engine, default phtml (phtml, volt) [optional]',
+            'use-config-ini'    => 'Use a ini file as configuration file [optional]',
+            'trace'             => 'Shows the trace of the framework in case of exception [optional]',
+            'help'              => 'Shows this help [optional]',
         ];
     }
 
@@ -60,12 +61,13 @@ class Project extends Command
      */
     public function run(array $parameters)
     {
-        $projectName = $this->getOption(['name', 1], null, 'default');
-        $projectType = $this->getOption(['type', 2], null, 'simple');
-        $projectPath = $this->getOption(['directory', 3]);
-        $templatePath = $this->getOption(['template-path'], null, TEMPLATE_PATH);
+        $projectName    = $this->getOption(['name', 1], null, 'default');
+        $projectType    = $this->getOption(['type', 2], null, 'simple');
+        $projectPath    = $this->getOption(['directory', 3]);
+        $templatePath   = $this->getOption(['template-path'], null, TEMPLATE_PATH);
         $enableWebtools = $this->getOption(['enable-webtools', 4], null, false);
-        $useConfigIni = $this->getOption('use-config-ini');
+        $useConfigIni   = $this->getOption('use-config-ini');
+        $templateEngine = $this->getOption(['template-engine'], null, "phtml");
 
         $builder = new ProjectBuilder([
             'name'           => $projectName,
@@ -73,6 +75,7 @@ class Project extends Command
             'directory'      => $projectPath,
             'enableWebTools' => $enableWebtools,
             'templatePath'   => $templatePath,
+            'templateEngine' => $templateEngine,
             'useConfigIni'   => $useConfigIni
         ]);
 

--- a/scripts/Phalcon/Commands/Builtin/Scaffold.php
+++ b/scripts/Phalcon/Commands/Builtin/Scaffold.php
@@ -47,7 +47,7 @@ class Scaffold extends Command
             'get-set'           => 'Attributes will be protected and have setters/getters. [optional]',
             'directory=s'       => 'Base path on which project was created [optional]',
             'template-path=s'   => 'Specify a template path [optional]',
-            'template-engine=s' => 'Define the template engine, default php (php, volt) [optional]',
+            'template-engine=s' => 'Define the template engine, default phtml (phtml, volt) [optional]',
             'force'             => 'Forces to rewrite generated code if they already exists [optional]',
             'trace'             => 'Shows the trace of the framework in case of exception [optional]',
             'ns-models=s'       => "Model's namespace [optional]",
@@ -67,7 +67,7 @@ class Scaffold extends Command
         $name = $this->getOption(['table-name', 1]);
         $templatePath = $this->getOption(['template-path'], null, TEMPLATE_PATH);
         $schema = $this->getOption('schema');
-        $templateEngine = $this->getOption(['template-engine'], null, "php");
+        $templateEngine = $this->getOption(['template-engine'], null, "phtml");
 
         $scaffoldBuilder = new ScaffoldBuilder([
             'name'                 => $name,

--- a/templates/project/micro/views/404.volt
+++ b/templates/project/micro/views/404.volt
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <title>Phalcon PHP Framework</title>
+    </head>
+    <body>
+        <div class="container">
+            <h1>Not found :(</h1>
+            <em>This page is located in views/404.volt</em>
+        </div>
+    </body>
+</html>

--- a/templates/project/micro/views/index.volt
+++ b/templates/project/micro/views/index.volt
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
+        <title>Phalcon PHP Framework</title>
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    </head>
+    <body>
+        <div class="container">
+
+            <div class="page-header">
+                <h1>Congratulations!</h1>
+            </div>
+
+            <p>You're now flying with Phalcon. Great things are about to happen!</p>
+
+            <p>This page is located at <code>views/index.volt</code></p>
+        </div>
+
+        <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
+        <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
+        <!-- Latest compiled and minified JavaScript -->
+        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+    </body>
+</html>


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #66

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:
Added option `--template-engine=s` for creating project. It makes possible to choose view engine `volt` or `phtml`

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
