### PR TITLE
Changed batchInsert method inserting data to table for migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ env:
     - TEST_DB_POSTGRESQL_USER="postgres"
     - TEST_DB_POSTGRESQL_PASSWD=""
     - TEST_DB_POSTGRESQL_NAME="devtools"
+    - TEST_DB_POSTGRESQL_SCHEMA="public"
     - TEST_DB_MYSQL_DSN="mysql:host=127.0.0.1;dbname=devtools"
     - TEST_DB_MYSQL_HOST="127.0.0.1"
     - TEST_DB_MYSQL_PORT="3306"

--- a/scripts/Phalcon/Mvc/Model/Migration.php
+++ b/scripts/Phalcon/Mvc/Model/Migration.php
@@ -37,6 +37,7 @@ use Phalcon\Db\Dialect\MysqlExtended;
 use Phalcon\Db\Adapter\Pdo\MysqlExtended as AdapterMysqlExtended;
 use Phalcon\Db\Dialect\PostgresqlExtended;
 use Phalcon\Db\Adapter\Pdo\PostgresqlExtended as AdapterPostgresqlExtended;
+use Phalcon\Utils\Nullify;
 
 /**
  * Phalcon\Mvc\Model\Migration
@@ -860,7 +861,8 @@ class Migration
                 $line
             );
 
-            self::$_connection->insert($tableName, $values, $fields);
+            $nullify = new Nullify();
+            self::$_connection->insert($tableName, $nullify($values), $fields);
             unset($line);
         }
         fclose($batchHandler);

--- a/scripts/Phalcon/Utils/Nullify.php
+++ b/scripts/Phalcon/Utils/Nullify.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+  +------------------------------------------------------------------------+
+  | Phalcon Developer Tools                                                |
+  +------------------------------------------------------------------------+
+  | Copyright (c) 2011-2016 Phalcon Team (https://www.phalconphp.com)      |
+  +------------------------------------------------------------------------+
+  | This source file is subject to the New BSD License that is bundled     |
+  | with this package in the file LICENSE.txt.                             |
+  |                                                                        |
+  | If you did not receive a copy of the license and are unable to         |
+  | obtain it through the world-wide-web, please send an email             |
+  | to license@phalconphp.com so we can send you a copy immediately.       |
+  +------------------------------------------------------------------------+
+  | Authors: Sergii Svyrydenko <sergey.v.sviridenko@gmail.com>             |
+  +------------------------------------------------------------------------+
+*/
+
+namespace Phalcon\Utils;
+
+class Nullify
+{
+    public function __invoke($values)
+    {
+        $vals = array_map(
+            function ($value) {
+                if (function_exists('mb_strtolower')){
+                    return mb_strtolower($value);
+                }
+            },
+            $values
+        );
+
+        foreach ($vals as $key => $value) {
+            if ($value == 'null'){
+                $values[$key] = null;
+            }
+        }
+
+        return $values;
+    }
+}

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -45,7 +45,7 @@ $defaults = [
     "TEST_DB_POSTGRESQL_HOST"   => '127.0.0.1',
     "TEST_DB_POSTGRESQL_PORT"   => 5432,
     "TEST_DB_POSTGRESQL_USER"   => 'postgres',
-    "TEST_DB_POSTGRESQL_PASSWD" => 'secret',
+    "TEST_DB_POSTGRESQL_PASSWD" => '',
     "TEST_DB_POSTGRESQL_NAME"   => 'devtools',
     "TEST_DB_POSTGRESQL_SCHEMA" => 'public',
 ];

--- a/tests/_data/console/app/postgresql/config.php
+++ b/tests/_data/console/app/postgresql/config.php
@@ -1,0 +1,22 @@
+<?php
+
+use Phalcon\Config;
+use Phalcon\Logger;
+
+return new Config([
+    'database' => [
+        'adapter'  => 'Postgresql',
+        'host'     => env('TEST_DB_POSTGRESQL_HOST', '127.0.0.1'),
+        'username' => env('TEST_DB_POSTGRESQL_USER', 'postgres'),
+        'password' => env('TEST_DB_POSTGRESQL_PASSWD', ''),
+        'dbname'   => env('TEST_DB_POSTGRESQL_NAME', 'devtools'),
+        'schema'   => env('TEST_DB_POSTGRESQL_SCHEMA', 'public')
+    ],
+    'logger' => [
+        'path'     => tests_path('_output/logs/console/postgresql/'),
+        'format'   => '%date% [%type%] %message%',
+        'date'     => 'D j H:i:s',
+        'logLevel' => Logger::DEBUG,
+        'filename' => 'tests.log',
+    ]
+]);

--- a/tests/_data/console/app/test_insert_delete/migrations/1.0.0/test_insert_delete.php
+++ b/tests/_data/console/app/test_insert_delete/migrations/1.0.0/test_insert_delete.php
@@ -1,0 +1,124 @@
+<?php 
+
+use Phalcon\Db\Column;
+use Phalcon\Db\Index;
+use Phalcon\Db\Reference;
+use Phalcon\Mvc\Model\Migration;
+
+/**
+ * Class TestInsertDeleteMigration_100
+ */
+class TestInsertDeleteMigration_100 extends Migration
+{
+    /**
+     * Define the table structure
+     *
+     * @return void
+     */
+    public function morph()
+    {
+        $this->morphTable('test_insert_delete', [
+                'columns' => [
+                    new Column(
+                        'id',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'notNull' => true,
+                            'autoIncrement' => true,
+                            'first' => true
+                        ]
+                    ),
+                    new Column(
+                        'login_type_id',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'notNull' => true,
+                            'after' => 'id'
+                        ]
+                    ),
+                    new Column(
+                        'username',
+                        [
+                            'type' => Column::TYPE_VARCHAR,
+                            'notNull' => true,
+                            'size' => 255,
+                            'after' => 'login_type_id'
+                        ]
+                    ),
+                    new Column(
+                        'name',
+                        [
+                            'type' => Column::TYPE_VARCHAR,
+                            'notNull' => true,
+                            'size' => 255,
+                            'after' => 'username'
+                        ]
+                    ),
+                    new Column(
+                        'email_addr',
+                        [
+                            'type' => Column::TYPE_VARCHAR,
+                            'notNull' => true,
+                            'size' => 255,
+                            'after' => 'name'
+                        ]
+                    ),
+                    new Column(
+                        'password',
+                        [
+                            'type' => Column::TYPE_VARCHAR,
+                            'notNull' => true,
+                            'size' => 255,
+                            'after' => 'email_addr'
+                        ]
+                    ),
+                    new Column(
+                        'phone_num',
+                        [
+                            'type' => Column::TYPE_BIGINTEGER,
+                            'after' => 'password'
+                        ]
+                    ),
+                    new Column(
+                        'token_id',
+                        [
+                            'type' => Column::TYPE_BIGINTEGER,
+                            'after' => 'phone_num'
+                        ]
+                    )
+                ],
+            ]
+        );
+    }
+
+    /**
+     * Run the migrations
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $this->batchInsert('test_insert_delete', [
+                'id',
+                'login_type_id',
+                'username',
+                'name',
+                'email_addr',
+                'password',
+                'phone_num',
+                'token_id'
+            ]
+        );
+    }
+
+    /**
+     * Reverse the migrations
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $this->batchDelete('test_insert_delete');
+    }
+
+}

--- a/tests/_data/console/app/test_insert_delete/migrations/1.0.1/test_insert_delete.dat
+++ b/tests/_data/console/app/test_insert_delete/migrations/1.0.1/test_insert_delete.dat
@@ -1,0 +1,1 @@
+1,1,superadmin1,"First name Last name",email@test.com,,1,NULL

--- a/tests/_data/console/app/test_insert_delete/migrations/1.0.1/test_insert_delete.php
+++ b/tests/_data/console/app/test_insert_delete/migrations/1.0.1/test_insert_delete.php
@@ -1,0 +1,124 @@
+<?php 
+
+use Phalcon\Db\Column;
+use Phalcon\Db\Index;
+use Phalcon\Db\Reference;
+use Phalcon\Mvc\Model\Migration;
+
+/**
+ * Class TestInsertDeleteMigration_101
+ */
+class TestInsertDeleteMigration_101 extends Migration
+{
+    /**
+     * Define the table structure
+     *
+     * @return void
+     */
+    public function morph()
+    {
+        $this->morphTable('test_insert_delete', [
+                'columns' => [
+                    new Column(
+                        'id',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'notNull' => true,
+                            'autoIncrement' => true,
+                            'first' => true
+                        ]
+                    ),
+                    new Column(
+                        'login_type_id',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'notNull' => true,
+                            'after' => 'id'
+                        ]
+                    ),
+                    new Column(
+                        'username',
+                        [
+                            'type' => Column::TYPE_VARCHAR,
+                            'notNull' => true,
+                            'size' => 255,
+                            'after' => 'login_type_id'
+                        ]
+                    ),
+                    new Column(
+                        'name',
+                        [
+                            'type' => Column::TYPE_VARCHAR,
+                            'notNull' => true,
+                            'size' => 255,
+                            'after' => 'username'
+                        ]
+                    ),
+                    new Column(
+                        'email_addr',
+                        [
+                            'type' => Column::TYPE_VARCHAR,
+                            'notNull' => true,
+                            'size' => 255,
+                            'after' => 'name'
+                        ]
+                    ),
+                    new Column(
+                        'password',
+                        [
+                            'type' => Column::TYPE_VARCHAR,
+                            'notNull' => true,
+                            'size' => 255,
+                            'after' => 'email_addr'
+                        ]
+                    ),
+                    new Column(
+                        'phone_num',
+                        [
+                            'type' => Column::TYPE_BIGINTEGER,
+                            'after' => 'password'
+                        ]
+                    ),
+                    new Column(
+                        'token_id',
+                        [
+                            'type' => Column::TYPE_BIGINTEGER,
+                            'after' => 'phone_num'
+                        ]
+                    )
+                ],
+            ]
+        );
+    }
+
+    /**
+     * Run the migrations
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $this->batchInsert('test_insert_delete', [
+                'id',
+                'login_type_id',
+                'username',
+                'name',
+                'email_addr',
+                'password',
+                'phone_num',
+                'token_id'
+            ]
+        );
+    }
+
+    /**
+     * Reverse the migrations
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $this->batchDelete('test_insert_delete');
+    }
+
+}

--- a/tests/_data/console/app/test_insert_delete/migrations/1.0.2/test_insert_delete.dat
+++ b/tests/_data/console/app/test_insert_delete/migrations/1.0.2/test_insert_delete.dat
@@ -1,0 +1,2 @@
+1,1,superadmin1,"First name Last name",email@test.com,,1,NULL
+2,2,superadmin2,"First name Last name",email@test.com,,NULL,NULL

--- a/tests/_data/console/app/test_insert_delete/migrations/1.0.2/test_insert_delete.php
+++ b/tests/_data/console/app/test_insert_delete/migrations/1.0.2/test_insert_delete.php
@@ -1,0 +1,124 @@
+<?php 
+
+use Phalcon\Db\Column;
+use Phalcon\Db\Index;
+use Phalcon\Db\Reference;
+use Phalcon\Mvc\Model\Migration;
+
+/**
+ * Class TestInsertDeleteMigration_102
+ */
+class TestInsertDeleteMigration_102 extends Migration
+{
+    /**
+     * Define the table structure
+     *
+     * @return void
+     */
+    public function morph()
+    {
+        $this->morphTable('test_insert_delete', [
+                'columns' => [
+                    new Column(
+                        'id',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'notNull' => true,
+                            'autoIncrement' => true,
+                            'first' => true
+                        ]
+                    ),
+                    new Column(
+                        'login_type_id',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'notNull' => true,
+                            'after' => 'id'
+                        ]
+                    ),
+                    new Column(
+                        'username',
+                        [
+                            'type' => Column::TYPE_VARCHAR,
+                            'notNull' => true,
+                            'size' => 255,
+                            'after' => 'login_type_id'
+                        ]
+                    ),
+                    new Column(
+                        'name',
+                        [
+                            'type' => Column::TYPE_VARCHAR,
+                            'notNull' => true,
+                            'size' => 255,
+                            'after' => 'username'
+                        ]
+                    ),
+                    new Column(
+                        'email_addr',
+                        [
+                            'type' => Column::TYPE_VARCHAR,
+                            'notNull' => true,
+                            'size' => 255,
+                            'after' => 'name'
+                        ]
+                    ),
+                    new Column(
+                        'password',
+                        [
+                            'type' => Column::TYPE_VARCHAR,
+                            'notNull' => true,
+                            'size' => 255,
+                            'after' => 'email_addr'
+                        ]
+                    ),
+                    new Column(
+                        'phone_num',
+                        [
+                            'type' => Column::TYPE_BIGINTEGER,
+                            'after' => 'password'
+                        ]
+                    ),
+                    new Column(
+                        'token_id',
+                        [
+                            'type' => Column::TYPE_BIGINTEGER,
+                            'after' => 'phone_num'
+                        ]
+                    )
+                ],
+            ]
+        );
+    }
+
+    /**
+     * Run the migrations
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $this->batchInsert('test_insert_delete', [
+                'id',
+                'login_type_id',
+                'username',
+                'name',
+                'email_addr',
+                'password',
+                'phone_num',
+                'token_id'
+            ]
+        );
+    }
+
+    /**
+     * Reverse the migrations
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $this->batchDelete('test_insert_delete');
+    }
+
+}

--- a/tests/_data/schemas/postgresql/dump.sql
+++ b/tests/_data/schemas/postgresql/dump.sql
@@ -30,7 +30,7 @@ SET default_with_oids = false;
 
 
 CREATE USER phalcon_user WITH PASSWORD '1234';
-GRANT ALL PRIVILEGES ON DATABASE devtools TO devtools;
+GRANT ALL PRIVILEGES ON DATABASE devtools TO phalcon_user;
 
 --
 -- Tables for testing describeReferences()
@@ -56,3 +56,25 @@ CREATE TABLE foreign_key_child (
 );
 
 ALTER TABLE public.foreign_key_child OWNER TO postgres;
+
+--
+-- Table for testing generating migrations and methods batchInsert(), batchDelete()
+--
+-- Table: test_insert_delete
+CREATE TABLE test_insert_delete (
+  id SERIAL,
+  login_type_id INTEGER NOT NULL,
+  username VARCHAR(255) NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  email_addr VARCHAR(255) NOT NULL,
+  password VARCHAR(255) NOT NULL,
+  phone_num BIGINT NULL,
+  token_id BIGINT NULL,
+  PRIMARY KEY (id),
+  UNIQUE (username)
+);
+
+ALTER TABLE public.test_insert_delete OWNER TO postgres;
+
+INSERT INTO public.test_insert_delete VALUES
+  (3, 3, 'superadmin3', 'First name Last name', 'email@test.com', '', NULL, null);

--- a/tests/_support/Helper/Utils/NullifyTrait.php
+++ b/tests/_support/Helper/Utils/NullifyTrait.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Helper\Utils;
+
+/**
+ * Helper\Utils
+ *
+ * @copyright (c) 2011-2017 Phalcon Team
+ * @link      https://phalconphp.com
+ * @author    Sergii Svyrydenko <sergey.v.sviridenko@gmail.com>
+ * @package   Helper\Utils
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+
+trait NullifyTrait
+{
+    protected function getInvokeData()
+    {
+        return [
+            0 => [1, 'test' , 'NULL', null],
+            1 => ['foo', 'bar', 'null', NULL],
+            2 => [1, 'foo', 'Null']
+        ];
+    }
+
+    protected function getInvokeExpected ()
+    {
+        return [
+            0 => [1, 'test', null, null],
+            1 => ['foo', 'bar', null, null],
+            2 => [1, 'foo', null]
+        ];
+    }
+}

--- a/tests/_support/helpers.php
+++ b/tests/_support/helpers.php
@@ -45,3 +45,14 @@ if (!function_exists('tests_path')) {
         return dirname(__DIR__) . DIRECTORY_SEPARATOR . ($path ? DIRECTORY_SEPARATOR . $path : $path);
     }
 }
+
+if (!function_exists('env')) {
+    function env($key, $default = null)
+    {
+        if (defined($key)) {
+            return constant($key);
+        }
+
+        return getenv($key) ?: $default;
+    }
+}

--- a/tests/console.suite.yml
+++ b/tests/console.suite.yml
@@ -10,3 +10,5 @@ modules:
         - Filesystem
         - Asserts
         - Cli
+    Phalcon:
+        bootstrap: 'tests/_bootstrap.php'

--- a/tests/console/GenerateMysqlMigrationCept.php
+++ b/tests/console/GenerateMysqlMigrationCept.php
@@ -14,6 +14,7 @@ OUT;
 
 $I->amInPath(dirname(app_path()));
 
+$I->deleteDir(app_path('migrations/1.0.2/'));
 $I->dontSeeFileFound(app_path('migrations/1.0.2/test_migrations.php'));
 $I->dontSeeFileFound(app_path('migrations/1.0.2/test_migrations.dat'));
 

--- a/tests/console/GeneratePostgresqlMigrationCept.php
+++ b/tests/console/GeneratePostgresqlMigrationCept.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @var Codeception\Scenario $scenario
+ */
+
+$I = new ConsoleTester($scenario);
+
+$I->wantToTest('Generating migration for Postgresql database');
+
+$output=<<<OUT
+Success: Version 1.0.3 was successfully generated
+OUT;
+
+$I->amInPath(dirname(app_path()));
+
+$I->deleteDir(app_path('test_insert_delete/migrations/1.0.3/'));
+$I->dontSeeFileFound(app_path('test_insert_delete/migrations/1.0.3/test_insert_delete.php'));
+$I->dontSeeFileFound(app_path('test_insert_delete/migrations/1.0.3/test_insert_delete.dat'));
+
+$I->runShellCommand('phalcon migration --action=generate --migrations=app/test_insert_delete/migrations --table=test_insert_delete --data=always --config=app/postgresql/config.php');
+
+$I->seeInShellOutput($output);
+
+$I->seeFileFound(app_path('test_insert_delete/migrations/1.0.3/test_insert_delete.php'));
+$I->seeFileFound(app_path('test_insert_delete/migrations/1.0.3/test_insert_delete.dat'));

--- a/tests/console/RunMysqlMigrationCept.php
+++ b/tests/console/RunMysqlMigrationCept.php
@@ -8,11 +8,8 @@ $I = new ConsoleTester($scenario);
 
 $I->wantToTest('Running migration for MySQL database');
 
-//$output=<<<OUT
-//Success: Version 1.0.1 was successfully migrated
-//OUT;
-
 $I->amInPath(dirname(app_path()));
+$I->cleanDir(tests_path('_data/console/.phalcon'));
 
 $I->seeFileFound(app_path('migrations/1.0.2/test_migrations.php'));
 $I->seeFileFound(app_path('migrations/1.0.2/test_migrations.dat'));
@@ -31,8 +28,10 @@ $I->seeInShellOutput('Success: Version 1.0.1 was successfully migrated');
 $I->runShellCommand('phalcon migration --action=run --version=1.0.2');
 $I->seeInShellOutput('Success: Version 1.0.2 was successfully migrated');
 
+$I->runShellCommand('phalcon migration --action=run --version=1.0.0');
 
 $I->deleteDir(app_path('migrations/1.0.2/'));
 
 $I->dontSeeFileFound(app_path('migrations/1.0.2/test_migrations.php'));
 $I->dontSeeFileFound(app_path('migrations/1.0.2/test_migrations.dat'));
+$I->cleanDir(tests_path('_data/console/.phalcon'));

--- a/tests/console/RunPostgresqlMigrationCept.php
+++ b/tests/console/RunPostgresqlMigrationCept.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @var Codeception\Scenario $scenario
+ */
+
+$I = new ConsoleTester($scenario);
+
+$I->wantToTest('Running migration for Posqgresql database');
+
+$I->amInPath(dirname(app_path()));
+$I->cleanDir(tests_path('_data/console/.phalcon'));
+
+$I->seeFileFound(app_path('test_insert_delete/migrations/1.0.3/test_insert_delete.php'));
+$I->seeFileFound(app_path('test_insert_delete/migrations/1.0.3/test_insert_delete.dat'));
+
+$I->runShellCommand('phalcon migration --action=run --config=app/postgresql/config.php --migrations=app/test_insert_delete/migrations/ --version=1.0.0');
+
+$I->runShellCommand('phalcon migration --action=run --config=app/postgresql/config.php --migrations=app/test_insert_delete/migrations/ --version=1.0.1');
+$I->seeInShellOutput('Success: Version 1.0.1 was successfully migrated');
+
+$I->runShellCommand('phalcon migration --action=run --config=app/postgresql/config.php --migrations=app/test_insert_delete/migrations/ --version=1.0.2');
+$I->seeInShellOutput('Success: Version 1.0.2 was successfully migrated');
+
+$I->runShellCommand('phalcon migration --action=run --config=app/postgresql/config.php --migrations=app/test_insert_delete/migrations/ --version=1.0.3');
+$I->seeInShellOutput('Success: Version 1.0.3 was successfully migrated');
+
+$I->runShellCommand('phalcon migration --action=run --config=app/postgresql/config.php --migrations=app/test_insert_delete/migrations/ --version=1.0.0');
+$I->seeInShellOutput('Success: Version 1.0.3 was successfully rolled back');
+
+$I->deleteDir(app_path('test_insert_delete/migrations/1.0.3/'));
+$I->dontSeeFileFound(app_path('test_insert_delete/migrations/1.0.3/test_insert_delete.php'));
+$I->dontSeeFileFound(app_path('test_insert_delete/migrations/1.0.3/test_insert_delete.dat'));
+$I->cleanDir(tests_path('_data/console/.phalcon'));

--- a/tests/unit/Utils/NullifyTest.php
+++ b/tests/unit/Utils/NullifyTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Phalcon\Test;
+
+use Phalcon\Utils\Nullify;
+use Phalcon\Test\Module\UnitTest;
+use Helper\Utils\NullifyTrait;
+
+/*
+  +------------------------------------------------------------------------+
+  | Phalcon Developer Tools                                                |
+  +------------------------------------------------------------------------+
+  | Copyright (c) 2011-2017 Phalcon Team (https://www.phalconphp.com)      |
+  +------------------------------------------------------------------------+
+  | This source file is subject to the New BSD License that is bundled     |
+  | with this package in the file LICENSE.txt.                             |
+  |                                                                        |
+  | If you did not receive a copy of the license and are unable to         |
+  | obtain it through the world-wide-web, please send an email             |
+  | to license@phalconphp.com so we can send you a copy immediately.       |
+  +------------------------------------------------------------------------+
+  | Authors: Sergii Svyrydenko <sergey.v.sviridenko@gmail.com>             |
+  +------------------------------------------------------------------------+
+*/
+
+class NullifyTest extends UnitTest
+{
+    use NullifyTrait;
+
+    /**
+     * Tests Nullify::__invoke
+     *
+     * @test
+     * @issue  988
+     * @author Sergii Svyrydenko <sergey.v.sviridenko@gmail.com>
+     * @since  2017-09-06
+     */
+    public function shouldTestInvoke()
+    {
+        $this->specify(
+            '',
+            function ($data, $expected) {
+                $nullify = new Nullify();
+                foreach ($data as $key => $value) {
+                    expect($nullify($value))->equals($expected[$key]);
+                }
+            },
+            [
+                'examples' => [
+                    [$this->getInvokeData(), $this->getInvokeExpected()]
+                ]
+            ]
+        );
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #988

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR

Small description of change:
Array with data for inserting has all values as string. Added checking `null` values in array for  `batchInsert()`.

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
