### PR TITLE
Added option --output to migration command

### DIFF
--- a/scripts/Phalcon/Commands/Builtin/Migration.php
+++ b/scripts/Phalcon/Commands/Builtin/Migration.php
@@ -54,6 +54,8 @@ class Migration extends Command
             'force'             => 'Forces to overwrite existing migrations',
             'ts-based'          => 'Timestamp based migration version',
             'log-in-db'         => 'Keep migrations log in the database table rather than in file',
+            'dry'               => 'Mode which should not modify anything',
+            'verbose'           => 'Shows details about the results of running',
             'no-auto-increment' => 'Disable auto increment (Generating only)',
             'help'              => 'Shows this help [optional]',
         ];
@@ -115,6 +117,8 @@ class Migration extends Command
         $exportData = $this->getOption('data');
         $action = $this->getOption(['action', 1]);
         $version = $this->getOption('version');
+        $dryMode = $this->isReceivedOption('dry') ? true : false;
+        $verboseMode = $this->isReceivedOption('verbose') ? true : false;
 
         switch ($action) {
             case 'generate':
@@ -128,6 +132,7 @@ class Migration extends Command
                     'noAutoIncrement' => $this->isReceivedOption('no-auto-increment'),
                     'config'          => $config,
                     'descr'           => $descr,
+                    'dry'             => $dryMode,
                 ]);
                 break;
             case 'run':
@@ -140,6 +145,7 @@ class Migration extends Command
                     'config'         => $config,
                     'version'        => $version,
                     'migrationsInDb' => $migrationsInDb,
+                    'verbose'        => $verboseMode,
                 ]);
                 break;
             case 'list':

--- a/scripts/Phalcon/Listeners/DbListener.php
+++ b/scripts/Phalcon/Listeners/DbListener.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Phalcon\Listeners;
+
+use Phalcon\Mvc\Model\Migration\Profiler;
+use Phalcon\Events\Event;
+
+class DbListener
+{
+    protected $_profiler;
+
+    public function __construct()
+    {
+        $this->_profiler = new Profiler();
+    }
+
+    public function beforeQuery(Event $event, $connection)
+    {
+        $this->_profiler->startProfile(
+            $connection->getSQLStatement()
+        );
+    }
+
+    public function afterQuery()
+    {
+        $this->_profiler->stopProfile();
+    }
+}

--- a/tests/_data/schemas/mysql/dump.sql
+++ b/tests/_data/schemas/mysql/dump.sql
@@ -24,3 +24,12 @@ INSERT into `test_migrations` SET
     `active` = 1,
     `created_at` = NOW(),
     `updated_at` = NOW();
+
+DROP TABLE IF EXISTS `test_dry_verbose`;
+CREATE TABLE `test_dry_verbose` (
+    `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+    `name` varchar(45) NOT NULL,
+    `created_at` datetime NOT NULL,
+    `active` tinyint(1) NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/tests/console/GenerateDryVerboseMigrationCept.php
+++ b/tests/console/GenerateDryVerboseMigrationCept.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @var Codeception\Scenario $scenario
+ */
+
+$I = new ConsoleTester($scenario);
+
+$I->wantToTest('Generating migartion with --dry mode anf without');
+
+$I->amInPath(dirname(app_path()));
+
+$I->cleanDir(app_path('test_dry_verbose/migrations'));
+
+$I->runShellCommand('phalcon migration --action=generate --migrations=app/test_dry_verbose/migrations --table=test_dry_verbose --config=app/mysql/config.php');
+$I->seeInShellOutput('Success: Version 1.0.0 was successfully generated');
+$I->seeFileFound(app_path('test_dry_verbose/migrations/1.0.0/test_dry_verbose.php'));
+
+$I->runShellCommand('phalcon migration --action=generate --migrations=app/test_dry_verbose/migrations --table=test_dry_verbose --config=app/mysql/config.php');
+$I->seeInShellOutput('Success: Version 1.0.1 was successfully generated');
+$I->seeFileFound(app_path('test_dry_verbose/migrations/1.0.1/test_dry_verbose.php'));
+
+$I->runShellCommand('phalcon migration --action=generate --migrations=app/test_dry_verbose/migrations --table=test_dry_verbose --config=app/mysql/config.php --dry');
+$I->seeInShellOutput('DESCRIBE `devtools`.`test_dry_verbose`');
+$I->dontSeeInShellOutput('Success: Version 1.0.2 was successfully generated');
+$I->dontSeeFileFound(app_path('test_dry_verbose/migrations/1.0.2/test_dry_verbose.dat'));

--- a/tests/console/RunDryVerboseMigrationCept.php
+++ b/tests/console/RunDryVerboseMigrationCept.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @var Codeception\Scenario $scenario
+ */
+
+$I = new ConsoleTester($scenario);
+
+$I->wantToTest('Running migration with --verbose mode and without');
+
+$I->amInPath(dirname(app_path()));
+$I->cleanDir(tests_path('_data/console/.phalcon'));
+
+$I->seeFileFound(app_path('test_dry_verbose/migrations/1.0.0/test_dry_verbose.php'));
+$I->seeFileFound(app_path('test_dry_verbose/migrations/1.0.1/test_dry_verbose.php'));
+
+$I->runShellCommand('phalcon migration --action=run --config=app/mysql/config.php --migrations=app/test_dry_verbose/migrations/ --version=1.0.0');
+$I->seeInShellOutput('Success: Version 1.0.0 was successfully migrated');
+$I->dontSeeInShellOutput('DESCRIBE `devtools`.`test_dry_verbose`');
+
+$I->runShellCommand('phalcon migration --action=run --config=app/mysql/config.php --migrations=app/test_dry_verbose/migrations/ --version=1.0.1');
+$I->seeInShellOutput('Success: Version 1.0.1 was successfully migrated');
+$I->dontSeeInShellOutput('DESCRIBE `devtools`.`test_dry_verbose`');
+
+$I->runShellCommand('phalcon migration --action=run --config=app/mysql/config.php --migrations=app/test_dry_verbose/migrations/ --version=1.0.0 --verbose');
+$I->seeInShellOutput('DESCRIBE `devtools`.`test_dry_verbose`');
+$I->seeInShellOutput('Success: Version 1.0.1 was successfully rolled back');
+
+$I->cleanDir(tests_path('_data/console/.phalcon'));
+$I->cleanDir(app_path('test_dry_verbose/migrations'));


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #215

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:
Added option `--output=s` for choosing of method where migration puts SQL queries into `.phalcon/migration.log` file or screen.

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
