### PR TITLE
Changed checking last version migration

### DIFF
--- a/scripts/Phalcon/Migrations.php
+++ b/scripts/Phalcon/Migrations.php
@@ -498,6 +498,7 @@ class Migrations
 
             if ($version = trim($version) ?: null) {
                 $version = preg_split('/\r\n|\r|\n/', $version, -1, PREG_SPLIT_NO_EMPTY);
+                natsort($version);
                 $version = array_pop($version);
             }
 

--- a/tests/_data/console/app/test_many_running/migrations/1.0.0/test_many_running.php
+++ b/tests/_data/console/app/test_many_running/migrations/1.0.0/test_many_running.php
@@ -1,0 +1,94 @@
+<?php 
+
+use Phalcon\Db\Column;
+use Phalcon\Db\Index;
+use Phalcon\Db\Reference;
+use Phalcon\Mvc\Model\Migration;
+
+/**
+ * Class TestManyRunningMigration_100
+ */
+class TestManyRunningMigration_100 extends Migration
+{
+    /**
+     * Define the table structure
+     *
+     * @return void
+     */
+    public function morph()
+    {
+        $this->morphTable('test_many_running', [
+                'columns' => [
+                    new Column(
+                        'id',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'unsigned' => true,
+                            'notNull' => true,
+                            'autoIncrement' => true,
+                            'size' => 10,
+                            'first' => true
+                        ]
+                    ),
+                    new Column(
+                        'name',
+                        [
+                            'type' => Column::TYPE_VARCHAR,
+                            'notNull' => true,
+                            'size' => 45,
+                            'after' => 'id'
+                        ]
+                    ),
+                    new Column(
+                        'created_at',
+                        [
+                            'type' => Column::TYPE_DATETIME,
+                            'notNull' => true,
+                            'size' => 1,
+                            'after' => 'name'
+                        ]
+                    ),
+                    new Column(
+                        'active',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'notNull' => true,
+                            'size' => 1,
+                            'after' => 'created_at'
+                        ]
+                    )
+                ],
+                'indexes' => [
+                    new Index('PRIMARY', ['id'], 'PRIMARY')
+                ],
+                'options' => [
+                    'TABLE_TYPE' => 'BASE TABLE',
+                    'AUTO_INCREMENT' => '1',
+                    'ENGINE' => 'InnoDB',
+                    'TABLE_COLLATION' => 'utf8_general_ci'
+                ],
+            ]
+        );
+    }
+
+    /**
+     * Run the migrations
+     *
+     * @return void
+     */
+    public function up()
+    {
+
+    }
+
+    /**
+     * Reverse the migrations
+     *
+     * @return void
+     */
+    public function down()
+    {
+
+    }
+
+}

--- a/tests/_data/console/app/test_many_running/migrations/1.0.1/test_many_running.php
+++ b/tests/_data/console/app/test_many_running/migrations/1.0.1/test_many_running.php
@@ -1,0 +1,94 @@
+<?php 
+
+use Phalcon\Db\Column;
+use Phalcon\Db\Index;
+use Phalcon\Db\Reference;
+use Phalcon\Mvc\Model\Migration;
+
+/**
+ * Class TestManyRunningMigration_101
+ */
+class TestManyRunningMigration_101 extends Migration
+{
+    /**
+     * Define the table structure
+     *
+     * @return void
+     */
+    public function morph()
+    {
+        $this->morphTable('test_many_running', [
+                'columns' => [
+                    new Column(
+                        'id',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'unsigned' => true,
+                            'notNull' => true,
+                            'autoIncrement' => true,
+                            'size' => 10,
+                            'first' => true
+                        ]
+                    ),
+                    new Column(
+                        'name',
+                        [
+                            'type' => Column::TYPE_VARCHAR,
+                            'notNull' => true,
+                            'size' => 45,
+                            'after' => 'id'
+                        ]
+                    ),
+                    new Column(
+                        'created_at',
+                        [
+                            'type' => Column::TYPE_DATETIME,
+                            'notNull' => true,
+                            'size' => 1,
+                            'after' => 'name'
+                        ]
+                    ),
+                    new Column(
+                        'active',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'notNull' => true,
+                            'size' => 1,
+                            'after' => 'created_at'
+                        ]
+                    )
+                ],
+                'indexes' => [
+                    new Index('PRIMARY', ['id'], 'PRIMARY')
+                ],
+                'options' => [
+                    'TABLE_TYPE' => 'BASE TABLE',
+                    'AUTO_INCREMENT' => '1',
+                    'ENGINE' => 'InnoDB',
+                    'TABLE_COLLATION' => 'utf8_general_ci'
+                ],
+            ]
+        );
+    }
+
+    /**
+     * Run the migrations
+     *
+     * @return void
+     */
+    public function up()
+    {
+
+    }
+
+    /**
+     * Reverse the migrations
+     *
+     * @return void
+     */
+    public function down()
+    {
+
+    }
+
+}

--- a/tests/_data/console/app/test_many_running/migrations/1.0.10/test_many_running.php
+++ b/tests/_data/console/app/test_many_running/migrations/1.0.10/test_many_running.php
@@ -1,0 +1,94 @@
+<?php 
+
+use Phalcon\Db\Column;
+use Phalcon\Db\Index;
+use Phalcon\Db\Reference;
+use Phalcon\Mvc\Model\Migration;
+
+/**
+ * Class TestManyRunningMigration_110
+ */
+class TestManyRunningMigration_110 extends Migration
+{
+    /**
+     * Define the table structure
+     *
+     * @return void
+     */
+    public function morph()
+    {
+        $this->morphTable('test_many_running', [
+                'columns' => [
+                    new Column(
+                        'id',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'unsigned' => true,
+                            'notNull' => true,
+                            'autoIncrement' => true,
+                            'size' => 10,
+                            'first' => true
+                        ]
+                    ),
+                    new Column(
+                        'name',
+                        [
+                            'type' => Column::TYPE_VARCHAR,
+                            'notNull' => true,
+                            'size' => 45,
+                            'after' => 'id'
+                        ]
+                    ),
+                    new Column(
+                        'created_at',
+                        [
+                            'type' => Column::TYPE_DATETIME,
+                            'notNull' => true,
+                            'size' => 1,
+                            'after' => 'name'
+                        ]
+                    ),
+                    new Column(
+                        'active',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'notNull' => true,
+                            'size' => 1,
+                            'after' => 'created_at'
+                        ]
+                    )
+                ],
+                'indexes' => [
+                    new Index('PRIMARY', ['id'], 'PRIMARY')
+                ],
+                'options' => [
+                    'TABLE_TYPE' => 'BASE TABLE',
+                    'AUTO_INCREMENT' => '1',
+                    'ENGINE' => 'InnoDB',
+                    'TABLE_COLLATION' => 'utf8_general_ci'
+                ],
+            ]
+        );
+    }
+
+    /**
+     * Run the migrations
+     *
+     * @return void
+     */
+    public function up()
+    {
+
+    }
+
+    /**
+     * Reverse the migrations
+     *
+     * @return void
+     */
+    public function down()
+    {
+
+    }
+
+}

--- a/tests/_data/console/app/test_many_running/migrations/1.0.11/test_many_running.php
+++ b/tests/_data/console/app/test_many_running/migrations/1.0.11/test_many_running.php
@@ -1,0 +1,94 @@
+<?php 
+
+use Phalcon\Db\Column;
+use Phalcon\Db\Index;
+use Phalcon\Db\Reference;
+use Phalcon\Mvc\Model\Migration;
+
+/**
+ * Class TestManyRunningMigration_111
+ */
+class TestManyRunningMigration_111 extends Migration
+{
+    /**
+     * Define the table structure
+     *
+     * @return void
+     */
+    public function morph()
+    {
+        $this->morphTable('test_many_running', [
+                'columns' => [
+                    new Column(
+                        'id',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'unsigned' => true,
+                            'notNull' => true,
+                            'autoIncrement' => true,
+                            'size' => 10,
+                            'first' => true
+                        ]
+                    ),
+                    new Column(
+                        'name',
+                        [
+                            'type' => Column::TYPE_VARCHAR,
+                            'notNull' => true,
+                            'size' => 45,
+                            'after' => 'id'
+                        ]
+                    ),
+                    new Column(
+                        'created_at',
+                        [
+                            'type' => Column::TYPE_DATETIME,
+                            'notNull' => true,
+                            'size' => 1,
+                            'after' => 'name'
+                        ]
+                    ),
+                    new Column(
+                        'active',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'notNull' => true,
+                            'size' => 1,
+                            'after' => 'created_at'
+                        ]
+                    )
+                ],
+                'indexes' => [
+                    new Index('PRIMARY', ['id'], 'PRIMARY')
+                ],
+                'options' => [
+                    'TABLE_TYPE' => 'BASE TABLE',
+                    'AUTO_INCREMENT' => '1',
+                    'ENGINE' => 'InnoDB',
+                    'TABLE_COLLATION' => 'utf8_general_ci'
+                ],
+            ]
+        );
+    }
+
+    /**
+     * Run the migrations
+     *
+     * @return void
+     */
+    public function up()
+    {
+
+    }
+
+    /**
+     * Reverse the migrations
+     *
+     * @return void
+     */
+    public function down()
+    {
+
+    }
+
+}

--- a/tests/_data/console/app/test_many_running/migrations/1.0.12/test_many_running.php
+++ b/tests/_data/console/app/test_many_running/migrations/1.0.12/test_many_running.php
@@ -1,0 +1,94 @@
+<?php 
+
+use Phalcon\Db\Column;
+use Phalcon\Db\Index;
+use Phalcon\Db\Reference;
+use Phalcon\Mvc\Model\Migration;
+
+/**
+ * Class TestManyRunningMigration_112
+ */
+class TestManyRunningMigration_112 extends Migration
+{
+    /**
+     * Define the table structure
+     *
+     * @return void
+     */
+    public function morph()
+    {
+        $this->morphTable('test_many_running', [
+                'columns' => [
+                    new Column(
+                        'id',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'unsigned' => true,
+                            'notNull' => true,
+                            'autoIncrement' => true,
+                            'size' => 10,
+                            'first' => true
+                        ]
+                    ),
+                    new Column(
+                        'name',
+                        [
+                            'type' => Column::TYPE_VARCHAR,
+                            'notNull' => true,
+                            'size' => 45,
+                            'after' => 'id'
+                        ]
+                    ),
+                    new Column(
+                        'created_at',
+                        [
+                            'type' => Column::TYPE_DATETIME,
+                            'notNull' => true,
+                            'size' => 1,
+                            'after' => 'name'
+                        ]
+                    ),
+                    new Column(
+                        'active',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'notNull' => true,
+                            'size' => 1,
+                            'after' => 'created_at'
+                        ]
+                    )
+                ],
+                'indexes' => [
+                    new Index('PRIMARY', ['id'], 'PRIMARY')
+                ],
+                'options' => [
+                    'TABLE_TYPE' => 'BASE TABLE',
+                    'AUTO_INCREMENT' => '1',
+                    'ENGINE' => 'InnoDB',
+                    'TABLE_COLLATION' => 'utf8_general_ci'
+                ],
+            ]
+        );
+    }
+
+    /**
+     * Run the migrations
+     *
+     * @return void
+     */
+    public function up()
+    {
+
+    }
+
+    /**
+     * Reverse the migrations
+     *
+     * @return void
+     */
+    public function down()
+    {
+
+    }
+
+}

--- a/tests/_data/console/app/test_many_running/migrations/1.0.2/test_many_running.php
+++ b/tests/_data/console/app/test_many_running/migrations/1.0.2/test_many_running.php
@@ -1,0 +1,94 @@
+<?php 
+
+use Phalcon\Db\Column;
+use Phalcon\Db\Index;
+use Phalcon\Db\Reference;
+use Phalcon\Mvc\Model\Migration;
+
+/**
+ * Class TestManyRunningMigration_102
+ */
+class TestManyRunningMigration_102 extends Migration
+{
+    /**
+     * Define the table structure
+     *
+     * @return void
+     */
+    public function morph()
+    {
+        $this->morphTable('test_many_running', [
+                'columns' => [
+                    new Column(
+                        'id',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'unsigned' => true,
+                            'notNull' => true,
+                            'autoIncrement' => true,
+                            'size' => 10,
+                            'first' => true
+                        ]
+                    ),
+                    new Column(
+                        'name',
+                        [
+                            'type' => Column::TYPE_VARCHAR,
+                            'notNull' => true,
+                            'size' => 45,
+                            'after' => 'id'
+                        ]
+                    ),
+                    new Column(
+                        'created_at',
+                        [
+                            'type' => Column::TYPE_DATETIME,
+                            'notNull' => true,
+                            'size' => 1,
+                            'after' => 'name'
+                        ]
+                    ),
+                    new Column(
+                        'active',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'notNull' => true,
+                            'size' => 1,
+                            'after' => 'created_at'
+                        ]
+                    )
+                ],
+                'indexes' => [
+                    new Index('PRIMARY', ['id'], 'PRIMARY')
+                ],
+                'options' => [
+                    'TABLE_TYPE' => 'BASE TABLE',
+                    'AUTO_INCREMENT' => '1',
+                    'ENGINE' => 'InnoDB',
+                    'TABLE_COLLATION' => 'utf8_general_ci'
+                ],
+            ]
+        );
+    }
+
+    /**
+     * Run the migrations
+     *
+     * @return void
+     */
+    public function up()
+    {
+
+    }
+
+    /**
+     * Reverse the migrations
+     *
+     * @return void
+     */
+    public function down()
+    {
+
+    }
+
+}

--- a/tests/_data/console/app/test_many_running/migrations/1.0.3/test_many_running.php
+++ b/tests/_data/console/app/test_many_running/migrations/1.0.3/test_many_running.php
@@ -1,0 +1,94 @@
+<?php 
+
+use Phalcon\Db\Column;
+use Phalcon\Db\Index;
+use Phalcon\Db\Reference;
+use Phalcon\Mvc\Model\Migration;
+
+/**
+ * Class TestManyRunningMigration_103
+ */
+class TestManyRunningMigration_103 extends Migration
+{
+    /**
+     * Define the table structure
+     *
+     * @return void
+     */
+    public function morph()
+    {
+        $this->morphTable('test_many_running', [
+                'columns' => [
+                    new Column(
+                        'id',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'unsigned' => true,
+                            'notNull' => true,
+                            'autoIncrement' => true,
+                            'size' => 10,
+                            'first' => true
+                        ]
+                    ),
+                    new Column(
+                        'name',
+                        [
+                            'type' => Column::TYPE_VARCHAR,
+                            'notNull' => true,
+                            'size' => 45,
+                            'after' => 'id'
+                        ]
+                    ),
+                    new Column(
+                        'created_at',
+                        [
+                            'type' => Column::TYPE_DATETIME,
+                            'notNull' => true,
+                            'size' => 1,
+                            'after' => 'name'
+                        ]
+                    ),
+                    new Column(
+                        'active',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'notNull' => true,
+                            'size' => 1,
+                            'after' => 'created_at'
+                        ]
+                    )
+                ],
+                'indexes' => [
+                    new Index('PRIMARY', ['id'], 'PRIMARY')
+                ],
+                'options' => [
+                    'TABLE_TYPE' => 'BASE TABLE',
+                    'AUTO_INCREMENT' => '1',
+                    'ENGINE' => 'InnoDB',
+                    'TABLE_COLLATION' => 'utf8_general_ci'
+                ],
+            ]
+        );
+    }
+
+    /**
+     * Run the migrations
+     *
+     * @return void
+     */
+    public function up()
+    {
+
+    }
+
+    /**
+     * Reverse the migrations
+     *
+     * @return void
+     */
+    public function down()
+    {
+
+    }
+
+}

--- a/tests/_data/console/app/test_many_running/migrations/1.0.4/test_many_running.php
+++ b/tests/_data/console/app/test_many_running/migrations/1.0.4/test_many_running.php
@@ -1,0 +1,94 @@
+<?php 
+
+use Phalcon\Db\Column;
+use Phalcon\Db\Index;
+use Phalcon\Db\Reference;
+use Phalcon\Mvc\Model\Migration;
+
+/**
+ * Class TestManyRunningMigration_104
+ */
+class TestManyRunningMigration_104 extends Migration
+{
+    /**
+     * Define the table structure
+     *
+     * @return void
+     */
+    public function morph()
+    {
+        $this->morphTable('test_many_running', [
+                'columns' => [
+                    new Column(
+                        'id',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'unsigned' => true,
+                            'notNull' => true,
+                            'autoIncrement' => true,
+                            'size' => 10,
+                            'first' => true
+                        ]
+                    ),
+                    new Column(
+                        'name',
+                        [
+                            'type' => Column::TYPE_VARCHAR,
+                            'notNull' => true,
+                            'size' => 45,
+                            'after' => 'id'
+                        ]
+                    ),
+                    new Column(
+                        'created_at',
+                        [
+                            'type' => Column::TYPE_DATETIME,
+                            'notNull' => true,
+                            'size' => 1,
+                            'after' => 'name'
+                        ]
+                    ),
+                    new Column(
+                        'active',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'notNull' => true,
+                            'size' => 1,
+                            'after' => 'created_at'
+                        ]
+                    )
+                ],
+                'indexes' => [
+                    new Index('PRIMARY', ['id'], 'PRIMARY')
+                ],
+                'options' => [
+                    'TABLE_TYPE' => 'BASE TABLE',
+                    'AUTO_INCREMENT' => '1',
+                    'ENGINE' => 'InnoDB',
+                    'TABLE_COLLATION' => 'utf8_general_ci'
+                ],
+            ]
+        );
+    }
+
+    /**
+     * Run the migrations
+     *
+     * @return void
+     */
+    public function up()
+    {
+
+    }
+
+    /**
+     * Reverse the migrations
+     *
+     * @return void
+     */
+    public function down()
+    {
+
+    }
+
+}

--- a/tests/_data/console/app/test_many_running/migrations/1.0.5/test_many_running.php
+++ b/tests/_data/console/app/test_many_running/migrations/1.0.5/test_many_running.php
@@ -1,0 +1,94 @@
+<?php 
+
+use Phalcon\Db\Column;
+use Phalcon\Db\Index;
+use Phalcon\Db\Reference;
+use Phalcon\Mvc\Model\Migration;
+
+/**
+ * Class TestManyRunningMigration_105
+ */
+class TestManyRunningMigration_105 extends Migration
+{
+    /**
+     * Define the table structure
+     *
+     * @return void
+     */
+    public function morph()
+    {
+        $this->morphTable('test_many_running', [
+                'columns' => [
+                    new Column(
+                        'id',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'unsigned' => true,
+                            'notNull' => true,
+                            'autoIncrement' => true,
+                            'size' => 10,
+                            'first' => true
+                        ]
+                    ),
+                    new Column(
+                        'name',
+                        [
+                            'type' => Column::TYPE_VARCHAR,
+                            'notNull' => true,
+                            'size' => 45,
+                            'after' => 'id'
+                        ]
+                    ),
+                    new Column(
+                        'created_at',
+                        [
+                            'type' => Column::TYPE_DATETIME,
+                            'notNull' => true,
+                            'size' => 1,
+                            'after' => 'name'
+                        ]
+                    ),
+                    new Column(
+                        'active',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'notNull' => true,
+                            'size' => 1,
+                            'after' => 'created_at'
+                        ]
+                    )
+                ],
+                'indexes' => [
+                    new Index('PRIMARY', ['id'], 'PRIMARY')
+                ],
+                'options' => [
+                    'TABLE_TYPE' => 'BASE TABLE',
+                    'AUTO_INCREMENT' => '1',
+                    'ENGINE' => 'InnoDB',
+                    'TABLE_COLLATION' => 'utf8_general_ci'
+                ],
+            ]
+        );
+    }
+
+    /**
+     * Run the migrations
+     *
+     * @return void
+     */
+    public function up()
+    {
+
+    }
+
+    /**
+     * Reverse the migrations
+     *
+     * @return void
+     */
+    public function down()
+    {
+
+    }
+
+}

--- a/tests/_data/console/app/test_many_running/migrations/1.0.6/test_many_running.php
+++ b/tests/_data/console/app/test_many_running/migrations/1.0.6/test_many_running.php
@@ -1,0 +1,94 @@
+<?php 
+
+use Phalcon\Db\Column;
+use Phalcon\Db\Index;
+use Phalcon\Db\Reference;
+use Phalcon\Mvc\Model\Migration;
+
+/**
+ * Class TestManyRunningMigration_106
+ */
+class TestManyRunningMigration_106 extends Migration
+{
+    /**
+     * Define the table structure
+     *
+     * @return void
+     */
+    public function morph()
+    {
+        $this->morphTable('test_many_running', [
+                'columns' => [
+                    new Column(
+                        'id',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'unsigned' => true,
+                            'notNull' => true,
+                            'autoIncrement' => true,
+                            'size' => 10,
+                            'first' => true
+                        ]
+                    ),
+                    new Column(
+                        'name',
+                        [
+                            'type' => Column::TYPE_VARCHAR,
+                            'notNull' => true,
+                            'size' => 45,
+                            'after' => 'id'
+                        ]
+                    ),
+                    new Column(
+                        'created_at',
+                        [
+                            'type' => Column::TYPE_DATETIME,
+                            'notNull' => true,
+                            'size' => 1,
+                            'after' => 'name'
+                        ]
+                    ),
+                    new Column(
+                        'active',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'notNull' => true,
+                            'size' => 1,
+                            'after' => 'created_at'
+                        ]
+                    )
+                ],
+                'indexes' => [
+                    new Index('PRIMARY', ['id'], 'PRIMARY')
+                ],
+                'options' => [
+                    'TABLE_TYPE' => 'BASE TABLE',
+                    'AUTO_INCREMENT' => '1',
+                    'ENGINE' => 'InnoDB',
+                    'TABLE_COLLATION' => 'utf8_general_ci'
+                ],
+            ]
+        );
+    }
+
+    /**
+     * Run the migrations
+     *
+     * @return void
+     */
+    public function up()
+    {
+
+    }
+
+    /**
+     * Reverse the migrations
+     *
+     * @return void
+     */
+    public function down()
+    {
+
+    }
+
+}

--- a/tests/_data/console/app/test_many_running/migrations/1.0.7/test_many_running.php
+++ b/tests/_data/console/app/test_many_running/migrations/1.0.7/test_many_running.php
@@ -1,0 +1,94 @@
+<?php 
+
+use Phalcon\Db\Column;
+use Phalcon\Db\Index;
+use Phalcon\Db\Reference;
+use Phalcon\Mvc\Model\Migration;
+
+/**
+ * Class TestManyRunningMigration_107
+ */
+class TestManyRunningMigration_107 extends Migration
+{
+    /**
+     * Define the table structure
+     *
+     * @return void
+     */
+    public function morph()
+    {
+        $this->morphTable('test_many_running', [
+                'columns' => [
+                    new Column(
+                        'id',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'unsigned' => true,
+                            'notNull' => true,
+                            'autoIncrement' => true,
+                            'size' => 10,
+                            'first' => true
+                        ]
+                    ),
+                    new Column(
+                        'name',
+                        [
+                            'type' => Column::TYPE_VARCHAR,
+                            'notNull' => true,
+                            'size' => 45,
+                            'after' => 'id'
+                        ]
+                    ),
+                    new Column(
+                        'created_at',
+                        [
+                            'type' => Column::TYPE_DATETIME,
+                            'notNull' => true,
+                            'size' => 1,
+                            'after' => 'name'
+                        ]
+                    ),
+                    new Column(
+                        'active',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'notNull' => true,
+                            'size' => 1,
+                            'after' => 'created_at'
+                        ]
+                    )
+                ],
+                'indexes' => [
+                    new Index('PRIMARY', ['id'], 'PRIMARY')
+                ],
+                'options' => [
+                    'TABLE_TYPE' => 'BASE TABLE',
+                    'AUTO_INCREMENT' => '1',
+                    'ENGINE' => 'InnoDB',
+                    'TABLE_COLLATION' => 'utf8_general_ci'
+                ],
+            ]
+        );
+    }
+
+    /**
+     * Run the migrations
+     *
+     * @return void
+     */
+    public function up()
+    {
+
+    }
+
+    /**
+     * Reverse the migrations
+     *
+     * @return void
+     */
+    public function down()
+    {
+
+    }
+
+}

--- a/tests/_data/console/app/test_many_running/migrations/1.0.8/test_many_running.php
+++ b/tests/_data/console/app/test_many_running/migrations/1.0.8/test_many_running.php
@@ -1,0 +1,94 @@
+<?php 
+
+use Phalcon\Db\Column;
+use Phalcon\Db\Index;
+use Phalcon\Db\Reference;
+use Phalcon\Mvc\Model\Migration;
+
+/**
+ * Class TestManyRunningMigration_108
+ */
+class TestManyRunningMigration_108 extends Migration
+{
+    /**
+     * Define the table structure
+     *
+     * @return void
+     */
+    public function morph()
+    {
+        $this->morphTable('test_many_running', [
+                'columns' => [
+                    new Column(
+                        'id',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'unsigned' => true,
+                            'notNull' => true,
+                            'autoIncrement' => true,
+                            'size' => 10,
+                            'first' => true
+                        ]
+                    ),
+                    new Column(
+                        'name',
+                        [
+                            'type' => Column::TYPE_VARCHAR,
+                            'notNull' => true,
+                            'size' => 45,
+                            'after' => 'id'
+                        ]
+                    ),
+                    new Column(
+                        'created_at',
+                        [
+                            'type' => Column::TYPE_DATETIME,
+                            'notNull' => true,
+                            'size' => 1,
+                            'after' => 'name'
+                        ]
+                    ),
+                    new Column(
+                        'active',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'notNull' => true,
+                            'size' => 1,
+                            'after' => 'created_at'
+                        ]
+                    )
+                ],
+                'indexes' => [
+                    new Index('PRIMARY', ['id'], 'PRIMARY')
+                ],
+                'options' => [
+                    'TABLE_TYPE' => 'BASE TABLE',
+                    'AUTO_INCREMENT' => '1',
+                    'ENGINE' => 'InnoDB',
+                    'TABLE_COLLATION' => 'utf8_general_ci'
+                ],
+            ]
+        );
+    }
+
+    /**
+     * Run the migrations
+     *
+     * @return void
+     */
+    public function up()
+    {
+
+    }
+
+    /**
+     * Reverse the migrations
+     *
+     * @return void
+     */
+    public function down()
+    {
+
+    }
+
+}

--- a/tests/_data/console/app/test_many_running/migrations/1.0.9/test_many_running.php
+++ b/tests/_data/console/app/test_many_running/migrations/1.0.9/test_many_running.php
@@ -1,0 +1,94 @@
+<?php 
+
+use Phalcon\Db\Column;
+use Phalcon\Db\Index;
+use Phalcon\Db\Reference;
+use Phalcon\Mvc\Model\Migration;
+
+/**
+ * Class TestManyRunningMigration_109
+ */
+class TestManyRunningMigration_109 extends Migration
+{
+    /**
+     * Define the table structure
+     *
+     * @return void
+     */
+    public function morph()
+    {
+        $this->morphTable('test_many_running', [
+                'columns' => [
+                    new Column(
+                        'id',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'unsigned' => true,
+                            'notNull' => true,
+                            'autoIncrement' => true,
+                            'size' => 10,
+                            'first' => true
+                        ]
+                    ),
+                    new Column(
+                        'name',
+                        [
+                            'type' => Column::TYPE_VARCHAR,
+                            'notNull' => true,
+                            'size' => 45,
+                            'after' => 'id'
+                        ]
+                    ),
+                    new Column(
+                        'created_at',
+                        [
+                            'type' => Column::TYPE_DATETIME,
+                            'notNull' => true,
+                            'size' => 1,
+                            'after' => 'name'
+                        ]
+                    ),
+                    new Column(
+                        'active',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'notNull' => true,
+                            'size' => 1,
+                            'after' => 'created_at'
+                        ]
+                    )
+                ],
+                'indexes' => [
+                    new Index('PRIMARY', ['id'], 'PRIMARY')
+                ],
+                'options' => [
+                    'TABLE_TYPE' => 'BASE TABLE',
+                    'AUTO_INCREMENT' => '1',
+                    'ENGINE' => 'InnoDB',
+                    'TABLE_COLLATION' => 'utf8_general_ci'
+                ],
+            ]
+        );
+    }
+
+    /**
+     * Run the migrations
+     *
+     * @return void
+     */
+    public function up()
+    {
+
+    }
+
+    /**
+     * Reverse the migrations
+     *
+     * @return void
+     */
+    public function down()
+    {
+
+    }
+
+}

--- a/tests/_data/schemas/mysql/dump.sql
+++ b/tests/_data/schemas/mysql/dump.sql
@@ -24,3 +24,12 @@ INSERT into `test_migrations` SET
     `active` = 1,
     `created_at` = NOW(),
     `updated_at` = NOW();
+
+DROP TABLE IF EXISTS `test_many_running`;
+CREATE TABLE `test_many_running` (
+    `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+    `name` varchar(45) NOT NULL,
+    `created_at` datetime NOT NULL,
+    `active` tinyint(1) NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/tests/console/RunMigrationCept.php
+++ b/tests/console/RunMigrationCept.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @var Codeception\Scenario $scenario
+ */
+
+$I = new ConsoleTester($scenario);
+
+$I->wantToTest('Running migration using migration file from .phalcon folder');
+
+$I->amInPath(dirname(app_path()));
+$I->cleanDir(tests_path('_data/console/.phalcon'));
+
+$I->runShellCommand('phalcon migration --action=run --config=app/mysql/config.php --migrations=app/test_many_running/migrations --table=test_many_running');
+$I->seeInShellOutput('Success: Version 1.0.12 was successfully migrated');
+
+$I->runShellCommand('phalcon migration --action=run --config=app/mysql/config.php --migrations=app/test_many_running/migrations --table=test_many_running --version=1.0.9');
+$I->seeInShellOutput('Success: Version 1.0.10 was successfully rolled back');
+
+$I->runShellCommand('phalcon migration --action=run --config=app/mysql/config.php --migrations=app/test_many_running/migrations --table=test_many_running --version=1.0.12');
+$I->seeInShellOutput('Success: Version 1.0.12 was successfully migrated');
+
+$I->cleanDir(tests_path('_data/console/.phalcon'));


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #1100

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR

Small description of change:
Getting current migration version from `.phalcon/migration-version` did without sorting

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
