### PR TITLE
Added option --dry --verbose to migration command

### DIFF
--- a/scripts/Phalcon/Commands/Builtin/Migration.php
+++ b/scripts/Phalcon/Commands/Builtin/Migration.php
@@ -4,7 +4,7 @@
   +------------------------------------------------------------------------+
   | Phalcon Developer Tools                                                |
   +------------------------------------------------------------------------+
-  | Copyright (c) 2011-2016 Phalcon Team (https://www.phalconphp.com)      |
+  | Copyright (c) 2011-2017 Phalcon Team (https://www.phalconphp.com)      |
   +------------------------------------------------------------------------+
   | This source file is subject to the New BSD License that is bundled     |
   | with this package in the file LICENSE.txt.                             |
@@ -54,6 +54,8 @@ class Migration extends Command
             'force'             => 'Forces to overwrite existing migrations',
             'ts-based'          => 'Timestamp based migration version',
             'log-in-db'         => 'Keep migrations log in the database table rather than in file',
+            'dry'               => 'Attempt requested operation without making changes to system (Generating only)',
+            'verbose'           => 'Output of debugging information during operation (Running only)',
             'no-auto-increment' => 'Disable auto increment (Generating only)',
             'help'              => 'Shows this help [optional]',
         ];
@@ -111,23 +113,21 @@ class Migration extends Command
         }
 
         $tableName = $this->isReceivedOption('table') ? $this->getOption('table') : '@';
-        $descr = $this->getOption('descr');
-        $exportData = $this->getOption('data');
         $action = $this->getOption(['action', 1]);
-        $version = $this->getOption('version');
 
         switch ($action) {
             case 'generate':
                 Migrations::generate([
                     'directory'       => $path,
                     'tableName'       => $tableName,
-                    'exportData'      => $exportData,
+                    'exportData'      => $this->getOption('data'),
                     'migrationsDir'   => $migrationsDir,
-                    'version'         => $version,
+                    'version'         => $this->getOption('version'),
                     'force'           => $this->isReceivedOption('force'),
                     'noAutoIncrement' => $this->isReceivedOption('no-auto-increment'),
                     'config'          => $config,
-                    'descr'           => $descr,
+                    'descr'           => $this->getOption('descr'),
+                    'verbose'         => $this->isReceivedOption('dry'),
                 ]);
                 break;
             case 'run':
@@ -138,8 +138,9 @@ class Migration extends Command
                     'force'          => $this->isReceivedOption('force'),
                     'tsBased'        => $migrationsTsBased,
                     'config'         => $config,
-                    'version'        => $version,
+                    'version'        => $this->getOption('version'),
                     'migrationsInDb' => $migrationsInDb,
+                    'verbose'        => $this->isReceivedOption('verbose'),
                 ]);
                 break;
             case 'list':
@@ -150,7 +151,7 @@ class Migration extends Command
                     'force'          => $this->isReceivedOption('force'),
                     'tsBased'        => $migrationsTsBased,
                     'config'         => $config,
-                    'version'        => $version,
+                    'version'        => $this->getOption('version'),
                     'migrationsInDb' => $migrationsInDb,
                 ]);
                 break;

--- a/scripts/Phalcon/Commands/Command.php
+++ b/scripts/Phalcon/Commands/Command.php
@@ -4,7 +4,7 @@
   +------------------------------------------------------------------------+
   | Phalcon Developer Tools                                                |
   +------------------------------------------------------------------------+
-  | Copyright (c) 2011-2016 Phalcon Team (https://www.phalconphp.com)      |
+  | Copyright (c) 2011-2017 Phalcon Team (https://www.phalconphp.com)      |
   +------------------------------------------------------------------------+
   | This source file is subject to the New BSD License that is bundled     |
   | with this package in the file LICENSE.txt.                             |

--- a/scripts/Phalcon/Listeners/DbProfilerListener.php
+++ b/scripts/Phalcon/Listeners/DbProfilerListener.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+  +------------------------------------------------------------------------+
+  | Phalcon Developer Tools                                                |
+  +------------------------------------------------------------------------+
+  | Copyright (c) 2011-2017 Phalcon Team (https://www.phalconphp.com)      |
+  +------------------------------------------------------------------------+
+  | This source file is subject to the New BSD License that is bundled     |
+  | with this package in the file LICENSE.txt.                             |
+  |                                                                        |
+  | If you did not receive a copy of the license and are unable to         |
+  | obtain it through the world-wide-web, please send an email             |
+  | to license@phalconphp.com so we can send you a copy immediately.       |
+  +------------------------------------------------------------------------+
+  | Authors: Sergii Svyrydenko <sergey.v.svyrydenko@gmail.com>             |
+  +------------------------------------------------------------------------+
+*/
+
+namespace Phalcon\Listeners;
+
+use Phalcon\Mvc\Model\Migration\Profiler;
+use Phalcon\Events\Event;
+
+/**
+ * Phalcon\Listeners\DbProfilerListener
+ *
+ * Db event listener
+ *
+ * @package Phalcon\Listeners
+ */
+class DbProfilerListener
+{
+    protected $_profiler;
+
+    public function __construct()
+    {
+        $this->_profiler = new Profiler();
+    }
+
+    public function beforeQuery(Event $event, $connection)
+    {
+        $this->_profiler->startProfile(
+            $connection->getSQLStatement()
+        );
+    }
+
+    public function afterQuery()
+    {
+        $this->_profiler->stopProfile();
+    }
+}

--- a/tests/_data/schemas/mysql/dump.sql
+++ b/tests/_data/schemas/mysql/dump.sql
@@ -33,3 +33,12 @@ CREATE TABLE `test_many_running` (
     `active` tinyint(1) NOT NULL,
     PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+DROP TABLE IF EXISTS `test_dry_verbose`;
+CREATE TABLE `test_dry_verbose` (
+    `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+    `name` varchar(45) NOT NULL,
+    `created_at` datetime NOT NULL,
+    `active` tinyint(1) NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/tests/console/GenerateDryVerboseMigrationCept.php
+++ b/tests/console/GenerateDryVerboseMigrationCept.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @var Codeception\Scenario $scenario
+ */
+
+$I = new ConsoleTester($scenario);
+
+$I->wantToTest('Generating migartion with --dry mode anf without');
+
+$I->amInPath(dirname(app_path()));
+
+$I->runShellCommand('phalcon migration --action=generate --migrations=app/test_dry_verbose/migrations --table=test_dry_verbose --config=app/mysql/config.php');
+$I->seeInShellOutput('Success: Version 1.0.0 was successfully generated');
+$I->seeFileFound(app_path('test_dry_verbose/migrations/1.0.0/test_dry_verbose.php'));
+
+$I->runShellCommand('phalcon migration --action=generate --migrations=app/test_dry_verbose/migrations --table=test_dry_verbose --config=app/mysql/config.php');
+$I->seeInShellOutput('Success: Version 1.0.1 was successfully generated');
+$I->seeFileFound(app_path('test_dry_verbose/migrations/1.0.1/test_dry_verbose.php'));
+
+$I->runShellCommand('phalcon migration --action=generate --migrations=app/test_dry_verbose/migrations --table=test_dry_verbose --config=app/mysql/config.php --dry');
+$I->seeInShellOutput('DESCRIBE `devtools`.`test_dry_verbose`');
+$I->dontSeeInShellOutput('Success: Version 1.0.2 was successfully generated');
+$I->dontSeeFileFound(app_path('test_dry_verbose/migrations/1.0.2/test_dry_verbose.dat'));

--- a/tests/console/RunDryVerboseMigrationCept.php
+++ b/tests/console/RunDryVerboseMigrationCept.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @var Codeception\Scenario $scenario
+ */
+
+$I = new ConsoleTester($scenario);
+
+$I->wantToTest('Running migration with --verbose mode and without');
+
+$I->amInPath(dirname(app_path()));
+$I->cleanDir(tests_path('_data/console/.phalcon'));
+
+$I->seeFileFound(app_path('test_dry_verbose/migrations/1.0.0/test_dry_verbose.php'));
+$I->seeFileFound(app_path('test_dry_verbose/migrations/1.0.1/test_dry_verbose.php'));
+
+$I->runShellCommand('phalcon migration --action=run --config=app/mysql/config.php --migrations=app/test_dry_verbose/migrations/ --version=1.0.0');
+$I->seeInShellOutput('Success: Version 1.0.0 was successfully migrated');
+$I->dontSeeInShellOutput('DESCRIBE `devtools`.`test_dry_verbose`');
+
+$I->runShellCommand('phalcon migration --action=run --config=app/mysql/config.php --migrations=app/test_dry_verbose/migrations/ --version=1.0.1');
+$I->seeInShellOutput('Success: Version 1.0.1 was successfully migrated');
+$I->dontSeeInShellOutput('DESCRIBE `devtools`.`test_dry_verbose`');
+
+$I->runShellCommand('phalcon migration --action=run --config=app/mysql/config.php --migrations=app/test_dry_verbose/migrations/ --version=1.0.0 --verbose');
+$I->seeInShellOutput('DESCRIBE `devtools`.`test_dry_verbose`');
+$I->seeInShellOutput('Success: Version 1.0.1 was successfully rolled back');
+
+$I->cleanDir(tests_path('_data/console/.phalcon'));
+$I->deleteDir(app_path('test_dry_verbose'));


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #215

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR

Small description of change:
Added option `--dry` and `--verbose` option for `migration` command. 

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
