### PR TITLE
fix wrong word case conversion

### DIFF
--- a/scripts/Phalcon/Builder/Scaffold.php
+++ b/scripts/Phalcon/Builder/Scaffold.php
@@ -282,7 +282,7 @@ class Scaffold extends Component
             if ($useGetSetters) {
                 $code .= 'set' . Text::camelize($field) . '(' . $fieldCode . ')';
             } else {
-                $code .= Text::camelize($field, '-') . ' = ' . $fieldCode;
+                $code .= $field . ' = ' . $fieldCode;
             }
 
             $code .= ';' . PHP_EOL . "\t\t";


### PR DESCRIPTION
Hello!
There seems to be an unnecessary conversion
* Type: bug fix | new feature | code quality | documentation
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR

Small description of change:

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md