### PR TITLE
Fix: model generation creates extra blackslashes in belongsTo with multi-part namespace

### DIFF
--- a/scripts/Phalcon/Builder/Model.php
+++ b/scripts/Phalcon/Builder/Model.php
@@ -285,7 +285,7 @@ class Model extends Component
             $initialize[] = $this->snippet->getRelation(
                 'belongsTo',
                 $this->options->get('camelize') ? Utils::lowerCamelize($columns[0]) : $columns[0],
-                $this->getEntityClassName($reference, $entityNamespace),
+                $entityNamespace . Text::camelize($tableName, '_-'),
                 $this->options->get('camelize') ? Utils::lowerCamelize($refColumns[0]) : $refColumns[0],
                 "['alias' => '" . Text::camelize($reference->getReferencedTable(), '_-') . "']"
             );


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:


When generating models that contain more than one part to the namespace, the belongsTo relationship would add an extra backslash in the Model reference.

Example:
`phalcon all-models --get-set --doc --mapcolumn --namespace=App\\Models`

Any models that contains a "belongsTo" relationship is created as follows:
```php
$this->belongsTo('user_id', 'App\Models\\Users', 'user_id', ['alias' => 'Users']);
```
My patch will create the expected output:
```php
$this->belongsTo('user_id', 'App\Models\Users', 'user_id', ['alias' => 'Users']);
```

Since the "hasMany" relationships are created correctly, I just copied the namespace code from hasMany and applied it to belongsTo. I also tested and confirmed this works with larger namespaces such as "`--namespace=My\\App\\V1\\Models`"

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
