### PR TITLE
Fixed capitals first character in properties

### DIFF
--- a/scripts/Phalcon/Builder/Scaffold.php
+++ b/scripts/Phalcon/Builder/Scaffold.php
@@ -280,9 +280,9 @@ class Scaffold extends Component
 
             $code .= '$' . Utils::lowerCamelizeWithDelimiter($var, '-', true) . '->';
             if ($useGetSetters) {
-                $code .= 'set' . Text::camelize($field) . '(' . $fieldCode . ')';
+                $code .= 'set' . Utils::lowerCamelizeWithDelimiter($field, '_', true) . '(' . $fieldCode . ')';
             } else {
-                $code .= Text::camelize($field, '-') . ' = ' . $fieldCode;
+                $code .= Utils::lowerCamelizeWithDelimiter($field, '-_', true) . ' = ' . $fieldCode;
             }
 
             $code .= ';' . PHP_EOL . "\t\t";


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #1114

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:
Fixed first character in public vars in controller when it was created by scaffold.
`$fooBar->SomeCol = $this->request->getPost("some-col");` - before.
`$fooBar->someCol = $this->request->getPost("some-col");` - after.
It was created in `createAction()` method.

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
