### PR TITLE
Added table prefix to generate/run migration

### DIFF
--- a/scripts/Phalcon/Commands/Builtin/Migration.php
+++ b/scripts/Phalcon/Commands/Builtin/Migration.php
@@ -47,7 +47,7 @@ class Migration extends Command
             'config=s'          => 'Configuration file',
             'migrations=s'      => 'Migrations directory',
             'directory=s'       => 'Directory where the project was created',
-            'table=s'           => 'Table to migrate. Default: all',
+            'table=s'           => 'Table to migrate. Table name or table prefix with asterisk. Default: all',
             'version=s'         => 'Version to migrate',
             'descr=s'           => 'Migration description (used for timestamp based migration)',
             'data=s'            => 'Export data [always|oncreate] (Import data when run migration)',

--- a/scripts/Phalcon/Console/OptionStack.php
+++ b/scripts/Phalcon/Console/OptionStack.php
@@ -19,6 +19,8 @@
 
 namespace Phalcon\Console;
 
+use Phalcon\Console\OptionParserTrait;
+
 /**
  * Phalcon\Console\OptionStack
  *
@@ -30,6 +32,8 @@ namespace Phalcon\Console;
  */
 class OptionStack
 {
+    use OptionParserTrait;
+
     /**
      * Parameters received by the script.
      * @var array
@@ -127,5 +131,16 @@ class OptionStack
     public function countOptions()
     {
         return count($this->options);
+    }
+
+    /**
+     * Indicates whether the script was a particular option.
+     *
+     * @param  string  $key
+     * @return boolean
+     */
+    public function isReceivedOption($key)
+    {
+        return isset($this->options[$key]);
     }
 }

--- a/scripts/Phalcon/Mvc/Model/Migration.php
+++ b/scripts/Phalcon/Mvc/Model/Migration.php
@@ -894,4 +894,14 @@ class Migration
         fclose($batchHandler);
         self::$_connection->commit();
     }
+
+    /**
+     * Get db connection
+     *
+     * @return \Phalcon\Db\AdapterInterface
+     */
+    public function getConnection()
+    {
+        return self::$_connection;
+    }
 }

--- a/scripts/Phalcon/Mvc/Model/Migration/TableAware/ListTablesDb.php
+++ b/scripts/Phalcon/Mvc/Model/Migration/TableAware/ListTablesDb.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+  +------------------------------------------------------------------------+
+  | Phalcon Developer Tools                                                |
+  +------------------------------------------------------------------------+
+  | Copyright (c) 2011-2017 Phalcon Team (https://www.phalconphp.com)      |
+  +------------------------------------------------------------------------+
+  | This source file is subject to the New BSD License that is bundled     |
+  | with this package in the file LICENSE.txt.                             |
+  |                                                                        |
+  | If you did not receive a copy of the license and are unable to         |
+  | obtain it through the world-wide-web, please send an email             |
+  | to license@phalconphp.com so we can send you a copy immediately.       |
+  +------------------------------------------------------------------------+
+  | Authors: Sergii Svyrydenko <sergey.v.sviridenko@gmail.com>             |
+  +------------------------------------------------------------------------+
+*/
+
+namespace Phalcon\Mvc\Model\Migration\TableAware;
+
+use Phalcon\Mvc\Model\Migration\TableAware\ListTablesInterface;
+use InvalidArgumentException;
+use Phalcon\Mvc\Model\Migration as ModelMigration;
+use Phalcon\Db\Exception as DbException;
+
+/**
+ * Phalcon\Mvc\Model\Migration\TableAware\ListTablesDb
+ *
+ * @package Phalcon\Mvc\Model\Migration\TableAware
+ */
+class ListTablesDb implements ListTablesInterface
+{
+    /**
+     * Get table names with prefix for running migration
+     *
+     * @param string $tablePrefix
+     * @param \DirectoryIterator $iterator
+     * @return string
+     */
+    public function listTablesForPrefix($tablePrefix, \DirectoryIterator $iterator = null)
+    {
+        if (empty($tablePrefix)) {
+            throw new InvalidArgumentException("Parameters weren't defined in " . __METHOD__);
+        }
+
+        $modelMigration = new ModelMigration();
+        $connection = $modelMigration->getConnection();
+
+        $tablesList = $connection->listTables();
+        if (empty($tablesList)) {
+            return '';
+        }
+
+        $strlen = strlen($tablePrefix);
+        foreach ($tablesList as $key => $value) {
+            if (substr($value, 0, $strlen) != $tablePrefix) {
+                unset($tablesList[$key]);
+            }
+        }
+
+        if (empty($tablesList)) {
+            throw new DbException("Specified table prefix doesn't match with any table name");
+        }
+
+        return implode(',', $tablesList);
+    }
+}

--- a/scripts/Phalcon/Mvc/Model/Migration/TableAware/ListTablesInterface.php
+++ b/scripts/Phalcon/Mvc/Model/Migration/TableAware/ListTablesInterface.php
@@ -13,37 +13,25 @@
   | obtain it through the world-wide-web, please send an email             |
   | to license@phalconphp.com so we can send you a copy immediately.       |
   +------------------------------------------------------------------------+
-  | Authors: Sergii Svyrydenko <sergey.v.svyrydenko@gmail.com>             |
+  | Authors: Sergii Svyrydenko <sergey.v.sviridenko@gmail.com>             |
   +------------------------------------------------------------------------+
 */
 
-namespace Phalcon\Console;
+namespace Phalcon\Mvc\Model\Migration\TableAware;
 
 /**
- * \Phalcon\Utils\OptionParserTrait
+ * Phalcon\Mvc\Model\Migration\TableAware\ListTablesInterface
  *
- * Parsing CLI options
- *
- * @package   Phalcon\Utils
- * @copyright Copyright (c) 2011-2017 Phalcon Team (team@phalconphp.com)
- * @license   New BSD License
+ * @package Phalcon\Mvc\Model\Migration\TableAware
  */
-trait OptionParserTrait
+interface ListTablesInterface
 {
     /**
-     * Get prefix from the option
+     * Get list table from prefix
      *
-     * @param  string  $prefix
-     * @param  mixed  $prefixEnd
-     *
-     * @return mixed
+     * @param string $tablePrefix Table prefix
+     * @param \DirectoryIterator $iterator
+     * @return string
      */
-    public function getPrefixOption($prefix, $prefixEnd = '*')
-    {
-        if (substr($prefix, -1) != $prefixEnd) {
-            return '';
-        }
-
-        return substr($prefix, 0, -1);
-    }
+    public function listTablesForPrefix($tablePrefix, \DirectoryIterator $iterator = null);
 }

--- a/scripts/Phalcon/Mvc/Model/Migration/TableAware/ListTablesIterator.php
+++ b/scripts/Phalcon/Mvc/Model/Migration/TableAware/ListTablesIterator.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+  +------------------------------------------------------------------------+
+  | Phalcon Developer Tools                                                |
+  +------------------------------------------------------------------------+
+  | Copyright (c) 2011-2017 Phalcon Team (https://www.phalconphp.com)      |
+  +------------------------------------------------------------------------+
+  | This source file is subject to the New BSD License that is bundled     |
+  | with this package in the file LICENSE.txt.                             |
+  |                                                                        |
+  | If you did not receive a copy of the license and are unable to         |
+  | obtain it through the world-wide-web, please send an email             |
+  | to license@phalconphp.com so we can send you a copy immediately.       |
+  +------------------------------------------------------------------------+
+  | Authors: Sergii Svyrydenko <sergey.v.sviridenko@gmail.com>             |
+  +------------------------------------------------------------------------+
+*/
+
+namespace Phalcon\Mvc\Model\Migration\TableAware;
+
+use Phalcon\Mvc\Model\Migration\TableAware\ListTablesInterface;
+use DirectoryIterator;
+use InvalidArgumentException;
+
+/**
+ * Phalcon\Mvc\Model\Migration\TableAware\ListTablesIterator
+ *
+ * @package Phalcon\Mvc\Model\Migration\TableAware
+ */
+class ListTablesIterator implements ListTablesInterface
+{
+    /**
+     * Get table names with prefix for running migration
+     *
+     * @param string $tablePrefix
+     * @param DirectoryIterator $iterator
+     * @return string
+     */
+    public function listTablesForPrefix($tablePrefix, DirectoryIterator $iterator = null)
+    {
+        if (empty($tablePrefix) || empty($iterator)) {
+            throw new InvalidArgumentException("Parameters weren't defined in " . __METHOD__);
+        }
+
+        $strlen = strlen($tablePrefix);
+        $fileNames = [];
+        foreach ($iterator as $fileInfo) {
+            if (substr($fileInfo->getFilename(), 0, $strlen) == $tablePrefix) {
+                $file = explode('.', $fileInfo->getFilename());
+                $fileNames[] = $file[0];
+            }
+        }
+
+        $fileNames = array_unique($fileNames);
+//        natsort($fileNames);
+
+        return implode(',', $fileNames);
+    }
+}

--- a/tests/_data/console/app/test_table_prefix/migrations/1.0.0/issue595_1.php
+++ b/tests/_data/console/app/test_table_prefix/migrations/1.0.0/issue595_1.php
@@ -1,0 +1,76 @@
+<?php 
+
+use Phalcon\Db\Column;
+use Phalcon\Db\Index;
+use Phalcon\Db\Reference;
+use Phalcon\Mvc\Model\Migration;
+
+/**
+ * Class Issue5951Migration_100
+ */
+class Issue5951Migration_100 extends Migration
+{
+    /**
+     * Define the table structure
+     *
+     * @return void
+     */
+    public function morph()
+    {
+        $this->morphTable('issue595_1', [
+                'columns' => [
+                    new Column(
+                        'id',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'unsigned' => true,
+                            'notNull' => true,
+                            'autoIncrement' => true,
+                            'size' => 10,
+                            'first' => true
+                        ]
+                    ),
+                    new Column(
+                        'name',
+                        [
+                            'type' => Column::TYPE_VARCHAR,
+                            'notNull' => true,
+                            'size' => 45,
+                            'after' => 'id'
+                        ]
+                    )
+                ],
+                'indexes' => [
+                    new Index('PRIMARY', ['id'], 'PRIMARY')
+                ],
+                'options' => [
+                    'TABLE_TYPE' => 'BASE TABLE',
+                    'AUTO_INCREMENT' => '1',
+                    'ENGINE' => 'InnoDB',
+                    'TABLE_COLLATION' => 'utf8_general_ci'
+                ],
+            ]
+        );
+    }
+
+    /**
+     * Run the migrations
+     *
+     * @return void
+     */
+    public function up()
+    {
+
+    }
+
+    /**
+     * Reverse the migrations
+     *
+     * @return void
+     */
+    public function down()
+    {
+
+    }
+
+}

--- a/tests/_data/console/app/test_table_prefix/migrations/1.0.0/issue595_2.php
+++ b/tests/_data/console/app/test_table_prefix/migrations/1.0.0/issue595_2.php
@@ -1,0 +1,76 @@
+<?php 
+
+use Phalcon\Db\Column;
+use Phalcon\Db\Index;
+use Phalcon\Db\Reference;
+use Phalcon\Mvc\Model\Migration;
+
+/**
+ * Class Issue5952Migration_100
+ */
+class Issue5952Migration_100 extends Migration
+{
+    /**
+     * Define the table structure
+     *
+     * @return void
+     */
+    public function morph()
+    {
+        $this->morphTable('issue595_2', [
+                'columns' => [
+                    new Column(
+                        'id',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'unsigned' => true,
+                            'notNull' => true,
+                            'autoIncrement' => true,
+                            'size' => 10,
+                            'first' => true
+                        ]
+                    ),
+                    new Column(
+                        'version',
+                        [
+                            'type' => Column::TYPE_INTEGER,
+                            'notNull' => true,
+                            'size' => 45,
+                            'after' => 'id'
+                        ]
+                    )
+                ],
+                'indexes' => [
+                    new Index('PRIMARY', ['id'], 'PRIMARY')
+                ],
+                'options' => [
+                    'TABLE_TYPE' => 'BASE TABLE',
+                    'AUTO_INCREMENT' => '1',
+                    'ENGINE' => 'InnoDB',
+                    'TABLE_COLLATION' => 'utf8_general_ci'
+                ],
+            ]
+        );
+    }
+
+    /**
+     * Run the migrations
+     *
+     * @return void
+     */
+    public function up()
+    {
+
+    }
+
+    /**
+     * Reverse the migrations
+     *
+     * @return void
+     */
+    public function down()
+    {
+
+    }
+
+}

--- a/tests/_data/schemas/mysql/dump.sql
+++ b/tests/_data/schemas/mysql/dump.sql
@@ -42,3 +42,22 @@ CREATE TABLE `test_dry_verbose` (
     `active` tinyint(1) NOT NULL,
     PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+--
+-- Table structure for testing table prefix, issue #595
+--
+DROP TABLE IF EXISTS `issue595_1`;
+CREATE TABLE `issue595_1` (
+    `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+    `name` varchar(45) NOT NULL,
+    `version` int(45) NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+DROP TABLE IF EXISTS `issue595_2`;
+CREATE TABLE `issue595_2` (
+    `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+    `version` int(45) NOT NULL,
+    `name` varchar(45) NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/tests/console/GenerateTablePrefixMigrationCept.php
+++ b/tests/console/GenerateTablePrefixMigrationCept.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @var Codeception\Scenario $scenario
+ */
+
+$I = new ConsoleTester($scenario);
+
+$I->wantToTest('Generating migration for testing table prefix');
+
+$I->amInPath(dirname(app_path()));
+
+$I->dontSeeFileFound(app_path('test_table_prefix/migrations/1.0.1/issue595_1.php'));
+$I->dontSeeFileFound(app_path('test_table_prefix/migrations/1.0.1/issue595_2.php'));
+
+$I->runShellCommand('phalcon migration --action=generate --config=app/mysql/config.php --migrations=app/test_table_prefix/migrations --table=issue595*');
+$I->seeInShellOutput('Success: Version 1.0.1 was successfully generated');
+
+$I->seeFileFound(app_path('test_table_prefix/migrations/1.0.1/issue595_1.php'));
+$I->seeFileFound(app_path('test_table_prefix/migrations/1.0.1/issue595_2.php'));

--- a/tests/console/RunTablePrefixMigrationCept.php
+++ b/tests/console/RunTablePrefixMigrationCept.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @var Codeception\Scenario $scenario
+ */
+
+$I = new ConsoleTester($scenario);
+
+$I->wantToTest('Running migration for testing table prefix');
+
+$I->amInPath(dirname(app_path()));
+$I->cleanDir(tests_path('_data/console/.phalcon'));
+
+$I->seeFileFound(app_path('test_table_prefix/migrations/1.0.1/issue595_1.php'));
+$I->seeFileFound(app_path('test_table_prefix/migrations/1.0.1/issue595_2.php'));
+
+$I->runShellCommand('phalcon migration --action=run --config=app/mysql/config.php --migrations=app/test_table_prefix/migrations/ --version=1.0.0 --table=issue595*');
+$I->seeInShellOutput('Success: Version 1.0.0 was successfully migrated');
+
+$I->runShellCommand('phalcon migration --action=run --config=app/mysql/config.php --migrations=app/test_table_prefix/migrations/ --version=1.0.1 --table=issue595*');
+$I->seeInShellOutput('Success: Version 1.0.1 was successfully migrated');
+
+$I->deleteDir(app_path('test_table_prefix/migrations/1.0.1/'));
+$I->dontSeeFileFound(app_path('test_table_prefix/migrations/1.0.1/issue595_1.php'));
+$I->dontSeeFileFound(app_path('test_table_prefix/migrations/1.0.1/issue595_2.php'));
+$I->cleanDir(tests_path('_data/console/.phalcon'));

--- a/tests/unit/Console/OptionStackTest.php
+++ b/tests/unit/Console/OptionStackTest.php
@@ -114,7 +114,7 @@ class OptionStackTest extends UnitTest
     }
 
     /**
-     * Tests OptionParserTrait::isReceivedOption
+     * Tests OptionStack::isReceivedOption
      *
      * @test
      * @author Sergii Svyrydenko <sergey.v.sviridenko@gmail.com>
@@ -132,8 +132,8 @@ class OptionStackTest extends UnitTest
             },
             [
                 'examples' => [
-                    [$this->isReceivedOption('true-option', $this->options->getOptions()), true],
-                    [$this->isReceivedOption('false-option', $this->options->getOptions()), false]
+                    [$this->options->isReceivedOption('true-option', $this->options->getOptions()), true],
+                    [$this->options->isReceivedOption('false-option', $this->options->getOptions()), false]
                 ]
             ]
         );
@@ -160,6 +160,58 @@ class OptionStackTest extends UnitTest
                 'examples' => [
                     [$this->options->getValidOption('test', 'bar'), 'foo'],
                     [$this->options->getValidOption('false-option', 'bar'), 'bar'],
+                ]
+            ]
+        );
+    }
+
+    /**
+     * Tests OptionParserTrait::getPrefixOption
+     *
+     * @test
+     * @issue  595
+     * @author Sergii Svyrydenko <sergey.v.sviridenko@gmail.com>
+     * @since  2017-10-06
+     */
+    public function shouldReturnPrefixFromOptionWithoutSetPrefix()
+    {
+        $this->options->setOptions(['test' => 'foo', 'test2' => 'bar']);
+
+        $this->specify(
+            'Method' . __METHOD__ . 'does not return option prefix',
+            function($prefix, $expected) {
+                expect($this->getPrefixOption($prefix))->equals($expected);
+            },
+            [
+                'examples' => [
+                    ['foo*', 'foo'],
+                    ['bar*', 'bar']
+                ]
+            ]
+        );
+    }
+
+    /**
+     * Tests OptionParserTrait::getPrefixOption
+     *
+     * @test
+     * @issue  595
+     * @author Sergii Svyrydenko <sergey.v.sviridenko@gmail.com>
+     * @since  2017-10-06
+     */
+    public function shouldReturnPrefixFromOptionWithSetPrefix()
+    {
+        $this->options->setOptions(['test' => 'foo', 'test2' => 'bar']);
+
+        $this->specify(
+            'Method' . __METHOD__ . 'does not return option prefix',
+            function($prefix, $prefixEnd, $expected) {
+                expect($this->getPrefixOption($prefix, $prefixEnd))->equals($expected);
+            },
+            [
+                'examples' => [
+                    ['foo^', '^', 'foo'],
+                    ['bar?', '?', 'bar']
                 ]
             ]
         );

--- a/tests/unit/Mvc/Model/Migration/TableAware/ListTablesDbTest.php
+++ b/tests/unit/Mvc/Model/Migration/TableAware/ListTablesDbTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Phalcon\Test\Mvc\Model\Migration\TableAware;
+
+use Phalcon\Test\Module\UnitTest;
+use Phalcon\Config;
+use Phalcon\Mvc\Model\Migration\TableAware\ListTablesDb;
+use Phalcon\Mvc\Model\Migration as ModelMigration;
+
+/*
+  +------------------------------------------------------------------------+
+  | Phalcon Developer Tools                                                |
+  +------------------------------------------------------------------------+
+  | Copyright (c) 2011-2017 Phalcon Team (https://www.phalconphp.com)      |
+  +------------------------------------------------------------------------+
+  | This source file is subject to the New BSD License that is bundled     |
+  | with this package in the file LICENSE.txt.                             |
+  |                                                                        |
+  | If you did not receive a copy of the license and are unable to         |
+  | obtain it through the world-wide-web, please send an email             |
+  | to license@phalconphp.com so we can send you a copy immediately.       |
+  +------------------------------------------------------------------------+
+  | Authors: Sergii Svyrydenko <sergey.v.sviridenko@gmail.com>             |
+  +------------------------------------------------------------------------+
+*/
+
+class ListTablesDbTest extends UnitTest
+{
+    public function _before()
+    {
+        parent::_before();
+
+        try {
+            $config = include(app_path('mysql/config.php'));
+            if (is_array($config)) {
+                $config = new Config($config);
+            }
+
+            ModelMigration::setup($config->database);
+        } catch (\PDOException $e) {
+            throw new \PHPUnit_Framework_SkippedTestError("Unable to connect to the database: " . $e->getMessage());
+        }
+    }
+
+    /**
+     * Tests ListTablesDb::listTablesForPrefix
+     *
+     * @test
+     * @issue  595
+     * @author Sergii Svyrydenko <sergey.v.sviridenko@gmail.com>
+     * @since  2017-10-06
+     */
+    public function shouldReturnListTablesFromDb()
+    {
+        $listTables = new ListTablesDb();
+
+        $this->specify(
+            'Method' . __METHOD__ . 'did not return table list',
+            function ($tablePrefix, $expected) use ($listTables) {
+                expect($listTables->listTablesForPrefix($tablePrefix))->equals($expected);
+            },
+            [
+                'examples' => [
+                    ['issue595', 'issue595_1,issue595_2']
+                ]
+            ]
+        );
+    }
+}

--- a/tests/unit/Mvc/Model/Migration/TableAware/ListTablesIteratorTest.php
+++ b/tests/unit/Mvc/Model/Migration/TableAware/ListTablesIteratorTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Phalcon\Test\Mvc\Model\Migration\TableAware;
+
+use Phalcon\Test\Module\UnitTest;
+use DirectoryIterator;
+use Phalcon\Mvc\Model\Migration\TableAware\ListTablesIterator;
+
+/*
+  +------------------------------------------------------------------------+
+  | Phalcon Developer Tools                                                |
+  +------------------------------------------------------------------------+
+  | Copyright (c) 2011-2017 Phalcon Team (https://www.phalconphp.com)      |
+  +------------------------------------------------------------------------+
+  | This source file is subject to the New BSD License that is bundled     |
+  | with this package in the file LICENSE.txt.                             |
+  |                                                                        |
+  | If you did not receive a copy of the license and are unable to         |
+  | obtain it through the world-wide-web, please send an email             |
+  | to license@phalconphp.com so we can send you a copy immediately.       |
+  +------------------------------------------------------------------------+
+  | Authors: Sergii Svyrydenko <sergey.v.sviridenko@gmail.com>             |
+  +------------------------------------------------------------------------+
+*/
+
+class ListTablesIteratorTest extends UnitTest
+{
+    /**
+     * Tests ListTablesIterator::listTablesForPrefix
+     *
+     * @test
+     * @issue  595
+     * @author Sergii Svyrydenko <sergey.v.sviridenko@gmail.com>
+     * @since  2017-10-06
+     */
+    public function shouldReturnListTablesFromIterator()
+    {
+        $iterator = new DirectoryIterator(app_path('test_table_prefix/migrations/1.0.0'));
+        $listTables = new ListTablesIterator();
+
+        $this->specify(
+            'Method' . __METHOD__ . 'did not return table list',
+            function($tablePrefix, $expected) use ($iterator, $listTables){
+                expect($listTables->listTablesForPrefix($tablePrefix, $iterator))->equals($expected);
+            },
+            [
+                'examples' => [
+                    ['issue', 'issue595_1,issue595_2']
+                ]
+            ]
+        );
+    }
+}


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #595

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR

Small description of change:
Added table prefix to generate/run migration.

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
