### PR TITLE
Fix devtools css path

### DIFF
--- a/scripts/Phalcon/Web/Tools.php
+++ b/scripts/Phalcon/Web/Tools.php
@@ -47,7 +47,7 @@ class Tools
         $path = $fsUtils->normalize(realpath($path)) . DS;
 
         $root = new SplFileInfo($path . 'public' . DS);
-        $fsUtils->setDirectoryPermission($root, ['js' => 0777]);
+        $fsUtils->setDirectoryPermission($root, ['js' => 0777, 'css' => 0777]);
 
         $tools = rtrim(str_replace(["\\", '/'], DS, PTOOLSPATH), DS);
 


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #1147

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:
Fix path where `.css` file will be put. 

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
