### PR TITLE
Corrected the Parentheses in 'if' on line 598

### DIFF
--- a/scripts/Phalcon/Builder/Scaffold.php
+++ b/scripts/Phalcon/Builder/Scaffold.php
@@ -595,7 +595,7 @@ class Scaffold extends Component
 
         $fileName = Text::uncamelize($this->options->get('fileName'));
         $viewPath = $dirPathLayouts . DIRECTORY_SEPARATOR . $fileName . '.volt';
-        if (!file_exists($viewPath || $this->options->contains('force'))) {
+        if (!file_exists($viewPath) || $this->options->contains('force')) {
 
             // View model layout
             $code = '';


### PR DESCRIPTION
Hello!

Small description of change:
The correct call to file_exists() should be with $viewPath as parameter AFAIK. The call should be `file_exists($viewPath)`. This could be a potential bug.

Thanks

