### PR TITLE
Fix field name in model method doc

### DIFF
--- a/scripts/Phalcon/Builder/Model.php
+++ b/scripts/Phalcon/Builder/Model.php
@@ -439,7 +439,7 @@ class Model extends Component
 
             if ($useSettersGetters) {
                 $methodName = Utils::camelize($field->getName(), '_-');
-                $setters[] = $this->snippet->getSetter($fieldName, $type, $methodName);
+                $setters[] = $this->snippet->getSetter($field->getName(), $fieldName, $type, $methodName);
 
                 if (isset($this->_typeMap[$type])) {
                     $getters[] = $this->snippet->getGetterMap($fieldName, $type, $methodName, $this->_typeMap[$type]);

--- a/scripts/Phalcon/Generator/Snippet.php
+++ b/scripts/Phalcon/Generator/Snippet.php
@@ -47,7 +47,7 @@ EOD;
         return PHP_EOL.sprintf($getSource, $source).PHP_EOL;
     }
 
-    public function getSetter($fieldName, $type, $setterName)
+    public function getSetter($originalFieldName, $fieldName, $type, $setterName)
     {
         $templateSetter = <<<EOD
     /**
@@ -63,7 +63,7 @@ EOD;
         return \$this;
     }
 EOD;
-        return PHP_EOL.sprintf($templateSetter, $fieldName, $type, $fieldName, $setterName, $fieldName, $fieldName, $fieldName).PHP_EOL;
+        return PHP_EOL.sprintf($templateSetter, $originalFieldName, $type, $fieldName, $setterName, $fieldName, $fieldName, $fieldName).PHP_EOL;
     }
 
     public function getValidateInclusion($fieldName, $varItems)


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: -

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:
Model generates method's wrong field description. I've field `ProducType`.
`Method to set the value of field producType` instead `Method to set the value of field `ProducType`

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
