### PR TITLE
Add option annotation to all-model command

### DIFF
--- a/scripts/Phalcon/Builder/AllModels.php
+++ b/scripts/Phalcon/Builder/AllModels.php
@@ -214,7 +214,8 @@ class AllModels extends Component
                     'mapColumn' => $mapColumn,
                     'abstract' => $this->options->get('abstract'),
                     'referenceList' => $referenceList,
-                    'camelize' => $this->options->get('camelize')
+                    'camelize' => $this->options->get('camelize'),
+                    'annotate' => $this->options->get('annotate'),
                 ]);
 
                 $modelBuilder->build();

--- a/scripts/Phalcon/Commands/Builtin/AllModels.php
+++ b/scripts/Phalcon/Commands/Builtin/AllModels.php
@@ -58,6 +58,7 @@ class AllModels extends Command
             'output=s'    => 'Folder where models are located [optional]',
             'mapcolumn'   => 'Get some code for map columns [optional]',
             'abstract'    => 'Abstract Model [optional]',
+            'annotate'    => 'Annotate Attributes [optional]',
             'help'        => 'Shows this help [optional]',
         ];
     }
@@ -128,6 +129,7 @@ class AllModels extends Command
             'mapColumn' => $this->isReceivedOption('mapcolumn'),
             'abstract' => $this->isReceivedOption('abstract'),
             'camelize' => $this->isReceivedOption('camelize'),
+            'annotate' => $this->isReceivedOption('annotate'),
         ]);
 
         $modelBuilder->build();

--- a/tests/console/GenerateMultyModelsCept.php
+++ b/tests/console/GenerateMultyModelsCept.php
@@ -10,7 +10,7 @@ $I->wantToTest('Generating models');
 $I->amInPath(dirname(app_path()));
 mkdir(tests_path('_data/console/app/models/all_model_test'), 0777, true);
 
-$I->runShellCommand('phalcon all-models --config=app/mysql/config.php --output=app/models/all_model_test');
+$I->runShellCommand('phalcon all-models --config=app/mysql/config.php --output=app/models/all_model_test --annotate');
 
 $I->seeFileFound(app_path('models/all_model_test/TestModel.php'));
 $I->seeFileFound(app_path('models/all_model_test/TestModel2.php'));


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: -

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:
Add option `annotate` to `all-model` command

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
