### PR TITLE
Delete define string type in method

### DIFF
--- a/scripts/Phalcon/Commands/DotPhalconMissingException.php
+++ b/scripts/Phalcon/Commands/DotPhalconMissingException.php
@@ -34,7 +34,7 @@ class DotPhalconMissingException extends CommandsException implements iSelfHeali
     const DEFAULT_MESSAGE = "This command must be run inside a Phalcon project with a .phalcon directory.";
     const RESOLUTION_PROMPT = "Shall I create the .phalcon directory now? (y/n)";
 
-    public function __construct (string $message = self::DEFAULT_MESSAGE , $code = 0)
+    public function __construct ($message = self::DEFAULT_MESSAGE , $code = 0)
     {
         $this->message = $message;
         $this->code = $code;
@@ -51,7 +51,7 @@ class DotPhalconMissingException extends CommandsException implements iSelfHeali
         fwrite(STDOUT, Color::info(self::RESOLUTION_PROMPT));
         $handle = fopen ("php://stdin","r");
         $line = fgets($handle);
-        if(trim($line) != 'y'){
+        if(trim(mb_strtolower($line)) != 'y'){
             echo "ABORTING!\n";
             return false;
         }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: -

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:
Delete definition string type in method 

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
