### PR TITLE
Add option to ignore `schema` in `initialize` function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 
 /composer.lock
 /vendor
+.idea

--- a/scripts/Phalcon/Builder/Model.php
+++ b/scripts/Phalcon/Builder/Model.php
@@ -159,7 +159,7 @@ class Model extends Component
             $schema = Utils::resolveDbSchema($config->database);
         }
 
-        if ($schema && !$this->modelOptions->hasOption('no-init-schema')) {
+        if ($schema && !$this->modelOptions->hasOption('noInitSchema')) {
             $initialize['schema'] = $snippet->getThisMethod('setSchema', $schema);
         }
         $initialize['source'] = $snippet->getThisMethod('setSource', $this->modelOptions->getOption('name'));

--- a/scripts/Phalcon/Builder/Model.php
+++ b/scripts/Phalcon/Builder/Model.php
@@ -159,7 +159,7 @@ class Model extends Component
             $schema = Utils::resolveDbSchema($config->database);
         }
 
-        if ($schema) {
+        if ($schema && !$this->modelOptions->hasOption('no-init-schema')) {
             $initialize['schema'] = $snippet->getThisMethod('setSchema', $schema);
         }
         $initialize['source'] = $snippet->getThisMethod('setSource', $this->modelOptions->getOption('name'));

--- a/scripts/Phalcon/Builder/Model.php
+++ b/scripts/Phalcon/Builder/Model.php
@@ -159,7 +159,7 @@ class Model extends Component
             $schema = Utils::resolveDbSchema($config->database);
         }
 
-        if ($schema && !$this->modelOptions->hasOption('noInitSchema')) {
+        if ($schema && !$this->modelOptions->getOption('noInitSchema')) {
             $initialize['schema'] = $snippet->getThisMethod('setSchema', $schema);
         }
         $initialize['source'] = $snippet->getThisMethod('setSource', $this->modelOptions->getOption('name'));

--- a/scripts/Phalcon/Commands/Builtin/Model.php
+++ b/scripts/Phalcon/Commands/Builtin/Model.php
@@ -48,6 +48,7 @@ class Model extends Command
         return [
             'name=s'          => 'Table name',
             'schema=s'        => 'Name of the schema [optional]',
+            'no-init-schema'  => 'Do not add schema into initialize function [optional]',
             'config=s'        => 'Configuration file [optional]',
             'namespace=s'     => "Model's namespace [optional]",
             'get-set'         => 'Attributes will be protected and have setters/getters [optional]',
@@ -84,6 +85,7 @@ class Model extends Command
                 'config'            => $this->getConfigObject(),
                 'className'         => $className,
                 'fileName'          => Text::uncamelize($className),
+                'noInitSchema'      => $this->isReceivedOption('no-init-schema'),
                 'genSettersGetters' => $this->isReceivedOption('get-set'),
                 'genDocMethods'     => $this->isReceivedOption('doc'),
                 'namespace'         => $this->getOption('namespace'),


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: None

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change: I want to use generated model in different servers (different schemas) so I don't want to add `schema` to model's `initialize` function.

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
