### PR TITLE
bugfix: webtools modelsNamespace typo

### DIFF
--- a/scripts/Phalcon/Web/Tools/Views/scaffold/generate.volt
+++ b/scripts/Phalcon/Web/Tools/Views/scaffold/generate.volt
@@ -13,9 +13,9 @@
                 </div>
                 <div class="box-body">
                     <div class="form-group">
-                        <label for="modelNamespace" class="col-sm-2 control-label">Model's namespace</label>
+                        <label for="modelsNamespace" class="col-sm-2 control-label">Model's namespace</label>
                         <div class="col-sm-10">
-                            {{ input("modelNamespace", 'eg. My\Awesome\Namespace') }}
+                            {{ input("modelsNamespace", 'eg. My\Awesome\Namespace') }}
                         </div>
                     </div>
 


### PR DESCRIPTION
This is tiny fix.

* Type: bug fix

Small description of change:

Scaffold generate parameter name modelNamespace to modelsNamespace in webtools.
