### PR TITLE
fix: Make provision to keep constant and propertie when generating Views

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,9 +4,7 @@ parameters:
     excludes_analyse:
         - %rootDir%/../../../scripts/Phalcon/Generator/*
         - %rootDir%/../../../scripts/Phalcon/Commands/DotPhalconMissingException.php
-        - %rootDir%/../../../scripts/Phalcon/Builder/Model.php
     ignoreErrors:
         - '#Call to an undefined method object::toArray().#'
         - '#supplied for foreach, only iterables are supported#'
         - '#Call to an undefined method [a-zA-Z0-9\\_]+::addMinor().#'
-        - '#Call to an undefined method ReflectionClass::getReflectionConstants().#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,8 +4,8 @@ parameters:
     excludes_analyse:
         - %rootDir%/../../../scripts/Phalcon/Generator/*
         - %rootDir%/../../../scripts/Phalcon/Commands/DotPhalconMissingException.php
+        - %rootDir%/../../../scripts/Phalcon/Builder/Model.php
     ignoreErrors:
         - '#Call to an undefined method object::toArray().#'
         - '#supplied for foreach, only iterables are supported#'
         - '#Call to an undefined method [a-zA-Z0-9\\_]+::addMinor().#'
-        - '#Call to an undefined method ReflectionClass::getReflectionConstants().#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,7 +4,9 @@ parameters:
     excludes_analyse:
         - %rootDir%/../../../scripts/Phalcon/Generator/*
         - %rootDir%/../../../scripts/Phalcon/Commands/DotPhalconMissingException.php
+        - %rootDir%/../../../scripts/Phalcon/Builder/Model.php
     ignoreErrors:
         - '#Call to an undefined method object::toArray().#'
         - '#supplied for foreach, only iterables are supported#'
         - '#Call to an undefined method [a-zA-Z0-9\\_]+::addMinor().#'
+        - '#Call to an undefined method ReflectionClass::getReflectionConstants().#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,3 +8,4 @@ parameters:
         - '#Call to an undefined method object::toArray().#'
         - '#supplied for foreach, only iterables are supported#'
         - '#Call to an undefined method [a-zA-Z0-9\\_]+::addMinor().#'
+        - '#Call to an undefined method ReflectionClass::getReflectionConstants().#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,3 +9,4 @@ parameters:
         - '#supplied for foreach, only iterables are supported#'
         - '#Call to an undefined method [a-zA-Z0-9\\_]+::addMinor().#'
         - '#Call to an undefined method ReflectionClass::getReflectionConstants\(\)\.#'
+    reportUnmatchedIgnoredErrors: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,4 +8,4 @@ parameters:
         - '#Call to an undefined method object::toArray().#'
         - '#supplied for foreach, only iterables are supported#'
         - '#Call to an undefined method [a-zA-Z0-9\\_]+::addMinor().#'
-        - #Call to an undefined method ReflectionClass::getReflectionConstants\(\)\.#
+        - '#Call to an undefined method ReflectionClass::getReflectionConstants\(\)\.#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,8 +4,8 @@ parameters:
     excludes_analyse:
         - %rootDir%/../../../scripts/Phalcon/Generator/*
         - %rootDir%/../../../scripts/Phalcon/Commands/DotPhalconMissingException.php
-        - %rootDir%/../../../scripts/Phalcon/Builder/Model.php
     ignoreErrors:
         - '#Call to an undefined method object::toArray().#'
         - '#supplied for foreach, only iterables are supported#'
         - '#Call to an undefined method [a-zA-Z0-9\\_]+::addMinor().#'
+        - #Call to an undefined method ReflectionClass::getReflectionConstants\(\)\.#

--- a/scripts/Phalcon/Builder/Model.php
+++ b/scripts/Phalcon/Builder/Model.php
@@ -219,6 +219,7 @@ class Model extends Component
         $alreadyFindFirst    = false;
         $alreadyColumnMapped = false;
         $alreadyGetSourced   = false;
+        $attributes          = [];
 
         if (file_exists($modelPath)) {
             try {
@@ -295,6 +296,106 @@ class Model extends Component
                             break;
                     }
                 }
+
+                $defaultProperties = $reflection->getDefaultProperties();
+                $possibleFields = [];
+                foreach ($fields as $field) {
+                    $possibleFields[$field->getName()] = true;
+                }
+
+                foreach ($reflection->getReflectionConstants() as $constant) {
+                    if ($constant->getDeclaringClass()->getName() != $fullClassName) {
+                        continue;
+                    }
+                    $constantsPreg = '/^(\s*)const(\s+)'.$constant->getName().'([\s=;]+)/';
+                    $endLine = $startLine = 0;
+                    foreach ($linesCode as $line => $code) {
+                        if (preg_match($constantsPreg, $code)) {
+                            $startLine = $line;
+                            break;
+                        }
+                    }
+                    if (!empty($startLine)) {
+                        $countLines = count($linesCode);
+                        for ($i = $startLine; $i < $countLines; $i++) {
+                            if (preg_match('/;(\s*)$/', $linesCode[$i])) {
+                                $endLine = $i;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (!empty($startLine) && !empty($endLine)) {
+                        $constantDeclaration = join(
+                            '',
+                            array_slice(
+                                $linesCode,
+                                $startLine,
+                                $endLine - $startLine + 1
+                            )
+                        );
+                        $attributes[] = PHP_EOL . "    " . $constant->getDocComment() . PHP_EOL . $constantDeclaration;
+
+                    }
+                }
+                foreach ($reflection->getProperties() as $propertie) {
+                    $propertieName = $propertie->getName();
+
+                    if ($propertie->getDeclaringClass()->getName() != $fullClassName || !empty($possibleFields[$propertieName])) {
+                        continue;
+                    }
+                    $modifiers = '';
+                    switch ($propertie->getModifiers()) {
+                        case \ReflectionProperty::IS_PUBLIC:
+                            $modifiersPreg = '^(\s*)public(\s+)';
+                            break;
+                        case \ReflectionProperty::IS_PRIVATE:
+                            $modifiersPreg = '^(\s*)private(\s+)';
+                            break;
+                        case \ReflectionProperty::IS_PROTECTED:
+                            $modifiersPreg = '^(\s*)protected(\s+)';
+                            break;
+                        case \ReflectionProperty::IS_STATIC + \ReflectionProperty::IS_PUBLIC:
+                            $modifiersPreg = '^(\s*)(public?)(\s+)static(\s+)';
+                            break;
+                        case \ReflectionProperty::IS_STATIC + \ReflectionProperty::IS_PROTECTED:
+                            $modifiersPreg = '^(\s*)protected(\s+)static(\s+)';
+                            break;
+                        case \ReflectionProperty::IS_STATIC + \ReflectionProperty::IS_PRIVATE:
+                            $modifiersPreg = '^(\s*)private(\s+)static(\s+)';
+                            break;
+                    }
+                    $modifiersPreg = '/' . $modifiersPreg . '\$' . $propertieName . '([\s=;]+)/';
+                    $endLine = $startLine = 0;
+                    foreach ($linesCode as $line => $code) {
+                        if (preg_match($modifiersPreg, $code)) {
+                            $startLine = $line;
+                            break;
+                        }
+                    }
+                    if (!empty($startLine)) {
+                        $countLines = count($linesCode);
+                        for ($i = $startLine; $i < $countLines; $i++) {
+                            if (preg_match('/;(\s*)$/', $linesCode[$i])) {
+                                $endLine = $i;
+                                break;
+                            }
+                        }
+                    }
+                    if (!empty($startLine) && !empty($endLine)) {
+                        $propertieDeclaration = join(
+                            '',
+                            array_slice(
+                                $linesCode,
+                                $startLine,
+                                $endLine - $startLine + 1
+                            )
+                        );
+                        $attributes[] = PHP_EOL . "    " . $propertie->getDocComment() . PHP_EOL . $propertieDeclaration;
+
+                    }
+                }
+
             } catch (\Exception $e) {
                 throw new RuntimeException(
                     sprintf(
@@ -353,7 +454,6 @@ class Model extends Component
             }
         }
 
-        $attributes = [];
         $setters = [];
         $getters = [];
         foreach ($fields as $field) {


### PR DESCRIPTION
Hello!

feature: Make provision to keep constant and propertie when generating Views

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR

Small description of change:

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
