### PR TITLE
#1277 - Changed logic of cphalcon ext path in ide/gen-stubs.php

### DIFF
--- a/ide/gen-stubs.php
+++ b/ide/gen-stubs.php
@@ -7,6 +7,11 @@
  *
  * *nix:    CPHALCON_DIR=/path/to/cphalcon/ext/ php ide/gen-stubs.php
  *  Win:    set CPHALCON_DIR=C:\Path\To\cphalcon\ext\ php ide/gen-stubs.php
+ *
+ * Alternative stubs generation
+ *
+ * cd cphalcon
+ * zephir stubs
  */
 
 if (!extension_loaded('phalcon')) {
@@ -17,6 +22,11 @@ if (getenv('CPHALCON_DIR') === false || !file_exists(getenv('CPHALCON_DIR'))) {
 	throw new Exception("CPHALCON directory does not exist");
 }
 
+/**
+ * Class Stubs_Generator
+ *
+ * @deprecated In version 4.x current class will be removed
+ */
 class Stubs_Generator
 {
 

--- a/ide/gen-stubs.php
+++ b/ide/gen-stubs.php
@@ -18,7 +18,21 @@ if (!extension_loaded('phalcon')) {
 	throw new Exception("phalcon extension isn't installed");
 }
 
-if (getenv('CPHALCON_DIR') === false || !file_exists(getenv('CPHALCON_DIR'))) {
+if (getenv('CPHALCON_DIR') === false) {
+    throw new Exception(<<<TEXT
+
+
+Specify CPHALCON_DIR env variable
+
+*nix:    CPHALCON_DIR=/path/to/cphalcon/ext/ php ide/gen-stubs.php
+Win:     set CPHALCON_DIR=C:\Path\To\cphalcon\ext\ php ide/gen-stubs.php
+
+
+TEXT
+);
+}
+
+if (!file_exists(getenv('CPHALCON_DIR'))) {
 	throw new Exception("CPHALCON directory does not exist");
 }
 

--- a/ide/gen-stubs.php
+++ b/ide/gen-stubs.php
@@ -3,18 +3,17 @@
 /**
  * This scripts generates the stubs to be used on IDEs
  *
- * Change the CPHALCON_DIR constant to point to the dev/ directory in the Phalcon source code
+ * Specify CPHALCON_DIR env variable to point to the dev/ directory in the Phalcon source code
  *
- * php ide/gen-stubs.php
+ * *nix:    CPHALCON_DIR=/path/to/cphalcon/ext/ php ide/gen-stubs.php
+ *  Win:    set CPHALCON_DIR=C:\Path\To\cphalcon\ext\ php ide/gen-stubs.php
  */
 
 if (!extension_loaded('phalcon')) {
 	throw new Exception("phalcon extension isn't installed");
 }
 
-define('CPHALCON_DIR' , '/Users/micate/Code/cphalcon/ext/');
-
-if (!file_exists(CPHALCON_DIR)) {
+if (getenv('CPHALCON_DIR') === false || !file_exists(getenv('CPHALCON_DIR'))) {
 	throw new Exception("CPHALCON directory does not exist");
 }
 
@@ -123,7 +122,7 @@ $version = Phalcon\Version::get();
 $versionPieces = explode(' ', $version);
 $genVersion = $versionPieces[0];
 
-$api = new Stubs_Generator(CPHALCON_DIR);
+$api = new Stubs_Generator(getenv('CPHALCON_DIR'));
 
 $classDocs = $api->getClassDocs();
 $docs = $api->getDocs();


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #1277

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Example of new usage:
```sh
cd /opt
git clone git@github.com:phalcon/cphalcon.git
cd /path/to/devtools
CPHALCON_DIR=/opt/cphalcon/ext/ php ide/gen-stubs.php
```

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
