### PR TITLE
fixes for issue #1235 and issue #1286

### DIFF
--- a/scripts/Phalcon/Builder/Model.php
+++ b/scripts/Phalcon/Builder/Model.php
@@ -180,7 +180,7 @@ class Model extends Component
                 }
 
                 $entityNamespace = '';
-                if ($this->modelOptions->getOption('namespace')) {
+                if ($this->modelOptions->hasOption('namespace')) {
                     $entityNamespace = $this->modelOptions->getOption('namespace')."\\";
                 }
 
@@ -198,8 +198,8 @@ class Model extends Component
 
         foreach ($db->describeReferences($this->modelOptions->getOption('name'), $schema) as $reference) {
             $entityNamespace = '';
-            if ($this->modelOptions->getOption('namespace')) {
-                $entityNamespace = $this->modelOptions->getOption('namespace');
+            if ($this->modelOptions->hasOption('namespace')) {
+                $entityNamespace = $this->modelOptions->getOption('namespace')."\\";
             }
 
             $refColumns = $reference->getReferencedColumns();
@@ -207,7 +207,7 @@ class Model extends Component
             $initialize[] = $snippet->getRelation(
                 'belongsTo',
                 $this->modelOptions->getOption('camelize') ? Utils::lowerCamelize($columns[0]) : $columns[0],
-                $this->getEntityClassName($reference, $entityNamespace),
+                $entityNamespace . Utils::camelize($reference->getReferencedTable()),
                 $this->modelOptions->getOption('camelize') ? Utils::lowerCamelize($refColumns[0]) : $refColumns[0],
                 "['alias' => '" . Text::camelize($reference->getReferencedTable(), '_-') . "']"
             );


### PR DESCRIPTION
all issues are in file: ```scripts/Phalcon/Builder/Model.php```

* bugfix: fixes issue #1235 

this issue occurs when creating model without using namespace it throws InvalidArgumentException when setting relations ```hasMany``` and ```belongsTo```

* bugfix: fixes issue #1286

this issue is when creating model without using namespace the ```Model::getEntityClassName``` method produces extra backslash only in belongsTo relation

example:
```php
$this->belongsTo('school_year_id', '\SchoolYear', 'school_year_id', ['alias' => 'SchoolYear']);
```
**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [Contributing Guidelines][:contrib:]
- [X] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:

changes to ```line #183``` and ```line #201```

changed ```getOption``` method to ```hasOption```

changes to  ``` line #202``` and ``` line #210```

backslash added only if namespace used

Thanks
