### PR TITLE
#1190 - Migration log index size fix

### DIFF
--- a/scripts/Phalcon/Migrations.php
+++ b/scripts/Phalcon/Migrations.php
@@ -496,7 +496,7 @@ class Migrations
                             'version',
                             [
                                 'type' => Column::TYPE_VARCHAR,
-                                'size' => 255,
+                                'size' => 190, // utf8: 255*3 = 765 bytes, utf8mb4: 255*4 = 1020 bytes
                                 'notNull' => true,
                             ]
                         ),


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #1190 

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Current fix is considered as _fast hotfix_ to migrations, due deprecation/removal of migrations in 4.0.

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
