### PR TITLE
fix: should not setSchema('foo') in initialize when we set --schema=""

### DIFF
--- a/scripts/Phalcon/Builder/AllModels.php
+++ b/scripts/Phalcon/Builder/AllModels.php
@@ -200,7 +200,7 @@ class AllModels extends Component
                 $modelBuilder = new Model([
                     'name' => $name,
                     'config' => $config,
-                    'schema' => $schema,
+                    'schema' => $this->options->get('schema', ''),
                     'extends' => $this->options->get('extends'),
                     'namespace' => $this->options->get('namespace'),
                     'force' => $forceProcess,

--- a/scripts/Phalcon/Builder/AllModels.php
+++ b/scripts/Phalcon/Builder/AllModels.php
@@ -200,7 +200,9 @@ class AllModels extends Component
                 $modelBuilder = new Model([
                     'name' => $name,
                     'config' => $config,
-                    'schema' => $this->options->get('schema', null),
+                    // We need to pass schema exactly as set in argv or config to Model
+                    // get disallows empty values, so we need to access raw options
+                    'schema' => isset($this->options->schema) ? $this->options->schema : null,
                     'extends' => $this->options->get('extends'),
                     'namespace' => $this->options->get('namespace'),
                     'force' => $forceProcess,

--- a/scripts/Phalcon/Builder/AllModels.php
+++ b/scripts/Phalcon/Builder/AllModels.php
@@ -200,7 +200,7 @@ class AllModels extends Component
                 $modelBuilder = new Model([
                     'name' => $name,
                     'config' => $config,
-                    'schema' => $this->options->get('schema', ''),
+                    'schema' => $this->options->get('schema', null),
                     'extends' => $this->options->get('extends'),
                     'namespace' => $this->options->get('namespace'),
                     'force' => $forceProcess,

--- a/scripts/Phalcon/Builder/Model.php
+++ b/scripts/Phalcon/Builder/Model.php
@@ -159,7 +159,7 @@ class Model extends Component
             $schema = Utils::resolveDbSchema($config->database);
         }
 
-        if ($schema) {
+        if (!empty($this->modelOptions->getOption('schema'))) {
             $initialize['schema'] = $snippet->getThisMethod('setSchema', $schema);
         }
         $initialize['source'] = $snippet->getThisMethod('setSource', $this->modelOptions->getOption('name'));

--- a/scripts/Phalcon/Builder/Model.php
+++ b/scripts/Phalcon/Builder/Model.php
@@ -153,15 +153,14 @@ class Model extends Component
 
         $initialize = [];
 
-        if ($this->modelOptions->hasOption('schema')) {
+        // use option schema if exists and is not empty
+        if ($this->modelOptions->hasOption('schema') && !empty($this->modelOptions->getOption('schema'))) {
             $schema = $this->modelOptions->getOption('schema');
+            $initialize['schema'] = $snippet->getThisMethod('setSchema', $schema);
         } else {
             $schema = Utils::resolveDbSchema($config->database);
         }
 
-        if (!empty($this->modelOptions->getOption('schema'))) {
-            $initialize['schema'] = $snippet->getThisMethod('setSchema', $schema);
-        }
         $initialize['source'] = $snippet->getThisMethod('setSource', $this->modelOptions->getOption('name'));
 
         $table = $this->modelOptions->getOption('name');

--- a/tests/_data/console/app/models/files/TestModel5.php
+++ b/tests/_data/console/app/models/files/TestModel5.php
@@ -1,0 +1,62 @@
+<?php
+
+class TestModel5 extends \Phalcon\Mvc\Model
+{
+
+    /**
+     *
+     * @var integer
+     * @Primary
+     * @Identity
+     * @Column(column="id", type="integer", length=10, nullable=false)
+     */
+    public $id;
+
+    /**
+     *
+     * @var string
+     * @Column(column="name", type="string", length=45, nullable=false)
+     */
+    public $name;
+
+    /**
+     * Initialize method for model.
+     */
+    public function initialize()
+    {
+        $this->setSource("TestModel5");
+    }
+
+    /**
+     * Returns table name mapped in the model.
+     *
+     * @return string
+     */
+    public function getSource()
+    {
+        return 'TestModel5';
+    }
+
+    /**
+     * Allows to query a set of records that match the specified conditions
+     *
+     * @param mixed $parameters
+     * @return TestModel5[]|TestModel5|\Phalcon\Mvc\Model\ResultSetInterface
+     */
+    public static function find($parameters = null)
+    {
+        return parent::find($parameters);
+    }
+
+    /**
+     * Allows to query the first record that match the specified conditions
+     *
+     * @param mixed $parameters
+     * @return TestModel5|\Phalcon\Mvc\Model\ResultInterface
+     */
+    public static function findFirst($parameters = null)
+    {
+        return parent::findFirst($parameters);
+    }
+
+}

--- a/tests/_data/schemas/mysql/dump.sql
+++ b/tests/_data/schemas/mysql/dump.sql
@@ -91,6 +91,12 @@ CREATE TABLE `Testmodel4` (
     PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
+CREATE TABLE `TestModel5` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(45) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
 --
 -- Table structures for testing generating scaffold
 --

--- a/tests/console/GenerateMultyModelsCept.php
+++ b/tests/console/GenerateMultyModelsCept.php
@@ -10,7 +10,7 @@ $I->wantToTest('Generating models');
 $I->amInPath(dirname(app_path()));
 mkdir(tests_path('_data/console/app/models/all_model_test'), 0777, true);
 
-$I->runShellCommand('phalcon all-models --config=app/mysql/config.php --output=app/models/all_model_test --annotate');
+$I->runShellCommand('phalcon all-models --config=app/mysql/config.php --output=app/models/all_model_test --annotate --schema=devtools');
 
 $I->seeFileFound(app_path('models/all_model_test/TestModel.php'));
 $I->seeFileFound(app_path('models/all_model_test/TestModel2.php'));

--- a/tests/console/GenerateMultyModelsCept.php
+++ b/tests/console/GenerateMultyModelsCept.php
@@ -8,14 +8,16 @@ $I = new ConsoleTester($scenario);
 
 $I->wantToTest('Generating models');
 $I->amInPath(dirname(app_path()));
-mkdir(tests_path('_data/console/app/models/all_model_test'), 0777, true);
+$dir = tests_path('_data/console/app/models/all_model_test');
+mkdir($dir, 0777, true);
 
-$I->runShellCommand('phalcon all-models --config=app/mysql/config.php --output=app/models/all_model_test --annotate --schema=devtools');
+$I->runShellCommand('phalcon all-models --config=app/mysql/config.php --output=app/models/all_model_test --annotate');
 
 $I->seeFileFound(app_path('models/all_model_test/TestModel.php'));
 $I->seeFileFound(app_path('models/all_model_test/TestModel2.php'));
 $I->seeFileFound(app_path('models/all_model_test/TestModel3.php'));
 $I->seeFileFound(app_path('models/all_model_test/Testmodel4.php'));
+$I->seeFileFound(app_path('models/all_model_test/TestModel5.php'));
 
 $file1 = file_get_contents(app_path('models/files/TestModel.php'));
 $file2 = file_get_contents(app_path('models/files/TestModel2.php'));
@@ -33,3 +35,12 @@ $I->seeFileContentsEqual($file3);
 
 $I->openFile(app_path('models/all_model_test/Testmodel4.php'));
 $I->seeFileContentsEqual($file4);
+
+$I->cleanDir($dir);
+
+$I->runShellCommand('phalcon all-models --config=app/mysql/config.php --output=app/models/all_model_test --annotate --schema=""');
+
+$file5 = file_get_contents(app_path('models/files/TestModel5.php'));
+
+$I->openFile(app_path('models/all_model_test/TestModel5.php'));
+$I->seeFileContentsEqual($file5);

--- a/tests/console/GenerateSingleModelCept.php
+++ b/tests/console/GenerateSingleModelCept.php
@@ -10,20 +10,23 @@ $I->wantToTest('Generating models');
 $I->amInPath(dirname(app_path()));
 mkdir(tests_path('_data/console/app/models/model_test'), 0777, true);
 
-$I->runShellCommand('phalcon model --config=app/mysql/config.php --name=testModel --output=app/models/model_test --annotate --schema=devtools');
-$I->runShellCommand('phalcon model --config=app/mysql/config.php --name=test-model2 --output=app/models/model_test --annotate --schema=devtools');
-$I->runShellCommand('phalcon model --config=app/mysql/config.php --name=test_model3 --output=app/models/model_test --annotate --schema=devtools');
-$I->runShellCommand('phalcon model --config=app/mysql/config.php --name=Testmodel4 --output=app/models/model_test --annotate --schema=devtools');
+$I->runShellCommand('phalcon model --config=app/mysql/config.php --name=testModel --output=app/models/model_test --annotate');
+$I->runShellCommand('phalcon model --config=app/mysql/config.php --name=test-model2 --output=app/models/model_test --annotate');
+$I->runShellCommand('phalcon model --config=app/mysql/config.php --name=test_model3 --output=app/models/model_test --annotate');
+$I->runShellCommand('phalcon model --config=app/mysql/config.php --name=Testmodel4 --output=app/models/model_test --annotate');
+$I->runShellCommand('phalcon model --config=app/mysql/config.php --name=TestModel5 --output=app/models/model_test --annotate --schema=""');
 
 $I->seeFileFound(app_path('models/model_test/TestModel.php'));
 $I->seeFileFound(app_path('models/model_test/TestModel2.php'));
 $I->seeFileFound(app_path('models/model_test/TestModel3.php'));
 $I->seeFileFound(app_path('models/model_test/Testmodel4.php'));
+$I->seeFileFound(app_path('models/model_test/TestModel5.php'));
 
 $file1 = file_get_contents(app_path('models/files/TestModel.php'));
 $file2 = file_get_contents(app_path('models/files/TestModel2.php'));
 $file3 = file_get_contents(app_path('models/files/TestModel3.php'));
 $file4 = file_get_contents(app_path('models/files/Testmodel4.php'));
+$file5 = file_get_contents(app_path('models/files/TestModel5.php'));
 
 $I->openFile(app_path('models/model_test/TestModel.php'));
 $I->seeFileContentsEqual($file1);
@@ -36,3 +39,6 @@ $I->seeFileContentsEqual($file3);
 
 $I->openFile(app_path('models/model_test/Testmodel4.php'));
 $I->seeFileContentsEqual($file4);
+
+$I->openFile(app_path('models/model_test/TestModel5.php'));
+$I->seeFileContentsEqual($file5);

--- a/tests/console/GenerateSingleModelCept.php
+++ b/tests/console/GenerateSingleModelCept.php
@@ -10,10 +10,10 @@ $I->wantToTest('Generating models');
 $I->amInPath(dirname(app_path()));
 mkdir(tests_path('_data/console/app/models/model_test'), 0777, true);
 
-$I->runShellCommand('phalcon model --config=app/mysql/config.php --name=testModel --output=app/models/model_test --annotate');
-$I->runShellCommand('phalcon model --config=app/mysql/config.php --name=test-model2 --output=app/models/model_test --annotate');
-$I->runShellCommand('phalcon model --config=app/mysql/config.php --name=test_model3 --output=app/models/model_test --annotate');
-$I->runShellCommand('phalcon model --config=app/mysql/config.php --name=Testmodel4 --output=app/models/model_test --annotate');
+$I->runShellCommand('phalcon model --config=app/mysql/config.php --name=testModel --output=app/models/model_test --annotate --schema=devtools');
+$I->runShellCommand('phalcon model --config=app/mysql/config.php --name=test-model2 --output=app/models/model_test --annotate --schema=devtools');
+$I->runShellCommand('phalcon model --config=app/mysql/config.php --name=test_model3 --output=app/models/model_test --annotate --schema=devtools');
+$I->runShellCommand('phalcon model --config=app/mysql/config.php --name=Testmodel4 --output=app/models/model_test --annotate --schema=devtools');
 
 $I->seeFileFound(app_path('models/model_test/TestModel.php'));
 $I->seeFileFound(app_path('models/model_test/TestModel2.php'));

--- a/tests/unit/Builder/ModelTest.php
+++ b/tests/unit/Builder/ModelTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Phalcon\Test\Builder;
+
+use Phalcon\Config;
+use Phalcon\Builder\Model;
+use Phalcon\Exception\RuntimeException;
+use Phalcon\Test\Module\UnitTest;
+
+/**
+ * @coversDefaultClass \Phalcon\Builder\Model
+ */
+class ModelTest extends UnitTest
+{
+
+    public function testConstructor()
+    {
+        $this->specify('should set default options', function() {
+
+            $model = new Model(
+                [
+                    'name' => 'test',
+                    'config' => [],
+                ]
+            );
+
+            $options = $model->getModelOptions()->getOptions();
+
+            $this->assertSame($options['camelize'], false);
+            $this->assertSame($options['force'], false);
+            $this->assertSame($options['className'], 'Test');
+            $this->assertSame($options['fileName'], 'Test');
+            $this->assertSame($options['abstract'], false);
+            $this->assertSame($options['annotate'], false);
+        });
+    }
+
+    public function testGetSchema()
+    {
+        $this->specify('should get schema from modelOptions if exists and not empty', function() {
+            $model = new Model(
+                [
+                    'name' => 'test',
+                    'schema' => 'correct_schema',
+                    'config' => new Config([
+                        'database' => [
+                            'schema' => 'wrong_schema'
+                        ]
+                    ]),
+                ]
+            );
+            $this->assertSame('correct_schema', $model->getSchema());
+        });
+
+        $this->specify('should get schema from config->database if modelOptions schema is empty', function() {
+            $model = new Model(
+                [
+                    'name' => 'test',
+                    'schema' => '',
+                    'config' => new Config([
+                        'database' => [
+                            'schema' => 'correct_schema'
+                        ]
+                    ]),
+                ]
+            );
+            $this->assertSame('correct_schema', $model->getSchema());
+        });
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testGetSchemaThrows()
+    {
+        $model = new Model(
+            [
+                'name' => 'test',
+                'schema' => '',
+                'config' => new Config([
+                    'database' => [
+                        'schema' => ''
+                    ]
+                ]),
+            ]
+        );
+        $model->getSchema();
+    }
+
+    public function testShouldInitSchema()
+    {
+        $this->specify('should not init if modelOption schema is ""', function (){
+            $model = new Model(
+                [
+                    'name' => 'test',
+                    'schema' => '',
+                    'config' => new Config([
+                        'database' => [
+                            'schema' => 'correct_schema'
+                        ]
+                    ]),
+                ]
+            );
+            $this->assertFalse($model->shouldInitSchema());
+        });
+
+        $this->specify('should init schema when modelOption schema is not ""', function() {
+            $model = new Model(
+                [
+                    'name' => 'test',
+                    'schema' => 'correct_schema',
+                    'config' => new Config([
+                        'database' => [
+                            'schema' => 'correct_schema'
+                        ]
+                    ]),
+                ]
+            );
+
+            $this->assertTrue($model->shouldInitSchema());
+
+            $model = new Model(
+                [
+                    'name' => 'test',
+                    'schema' => null,
+                    'config' => new Config([
+                        'database' => [
+                            'schema' => 'correct_schema'
+                        ]
+                    ]),
+                ]
+            );
+
+            $this->assertTrue($model->shouldInitSchema());
+
+            $model = new Model(
+                [
+                    'name' => 'test',
+                    'config' => new Config([
+                        'database' => [
+                            'schema' => 'correct_schema'
+                        ]
+                    ]),
+                ]
+            );
+
+            $this->assertTrue($model->shouldInitSchema());
+        });
+    }
+}

--- a/tests/unit/Builder/ModelTest.php
+++ b/tests/unit/Builder/ModelTest.php
@@ -66,6 +66,21 @@ class ModelTest extends UnitTest
             );
             $this->assertSame('correct_schema', $model->getSchema());
         });
+
+        $this->specify('should get schema from config->database if modelOptions schema is empty', function() {
+            $model = new Model(
+                [
+                    'name' => 'test',
+                    'schema' => null,
+                    'config' => new Config([
+                        'database' => [
+                            'schema' => 'correct_schema'
+                        ]
+                    ]),
+                ]
+            );
+            $this->assertSame('correct_schema', $model->getSchema());
+        });
     }
 
     /**


### PR DESCRIPTION
Hello!

* Type: bug fix
* issue:

#1162
This may be a better solution than #1255 

We expect that setting --schema="" will not add `setSchema()` in `initialize()`.

**Please check if fix provides desired behaviour.  If not I'll look into fixing #1255  ^^**

---

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR

---

- another pull request for this issue exists, but looks stale and this may be the better solution.
- this PR passes the option schema value from `AllModels::build` to `Models`.  
- we still use the schema from config to get our adapter instance
- this allows behaviour as described here: https://forum.phalconphp.com/discussion/15823/phalcon-tools-setschema-by-default-now

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
