### PR TITLE
Add PHP 7.3 and Phalcon v3.4.4 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,30 @@
 language: php
 
 sudo: required
-dist: trusty
-
-php:
-  - 5.5
-  - 5.6
 
 services:
   - postgresql
+  - mysql
 
 matrix:
   include:
-    - php: 7.0
+    - php: '5.5'
+      env: PHALCON_VERSION="v3.4.1"
+      dist: trusty
+    - php: '5.6'
+    - php: '7.0'
       env: ZEND_BACKEND="--backend=ZendEngine3"
-    - php: 7.1
+    - php: '7.1'
       env: ZEND_BACKEND="--backend=ZendEngine3"
-    - php: 7.2
+    - php: '7.2'
+      env: ZEND_BACKEND="--backend=ZendEngine3"
+    - php: '7.3'
       env: ZEND_BACKEND="--backend=ZendEngine3"
 
 git:
   depth: 1
 
 cache:
-  apt: true
   ccache: true
   timeout: 691200
   directories:
@@ -38,7 +39,7 @@ env:
   global:
     - PATH="$PATH:~/bin"
     - DISPLAY=":99.0"
-    - PHALCON_VERSION="v3.4.0"
+    - PHALCON_VERSION="v3.4.4"
 
 before_install:
   - export PHP_VERSION=$(php-config --version)
@@ -48,7 +49,7 @@ before_install:
   - export $(cut -d= -f1 $TRAVIS_BUILD_DIR/tests/_ci/environment)
   - phpenv config-rm xdebug.ini || true
   - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com $GH_TOKEN; fi;
-  - if [ ! -f "$HOME/cphalcon/$PHALCON_VERSION/tests/_ci/phalcon.ini" ]; then git clone -q --depth=1 https://github.com/phalcon/cphalcon.git $HOME/cphalcon/$PHALCON_VERSION >/dev/null 2>&1; fi;
+  - if [ ! -f "$HOME/cphalcon/$PHALCON_VERSION/tests/_ci/phalcon.ini" ]; then git clone -q --branch $PHALCON_VERSION --depth=1 https://github.com/phalcon/cphalcon.git $HOME/cphalcon/$PHALCON_VERSION >/dev/null 2>&1; fi;
   - bash tests/_ci/setup_dbs.sh
 
 install:
@@ -76,10 +77,3 @@ notifications:
       - build@phalconphp.com
     on_success: change
     on_failure: always
-
-addons:
-  apt:
-    packages:
-      - mysql-server-5.6
-      - mysql-client-core-5.6
-      - mysql-client-5.6

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "forum": "https://forum.phalconphp.com/"
     },
     "require": {
-        "php": ">=5.5 < 7.3.2 || >7.3.3",
+        "php": ">=5.5,!=7.3.2",
         "ext-phalcon": "~3.3",
         "psy/psysh": "~0.9",
         "nikic/php-parser": "^3.1"


### PR DESCRIPTION
Hello!

* Type: code quality
* Link to issue: -

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:

* Add PHP 7.3 to Travis
* Use latest stable version of Phalcon (v3.4.4) in Travis (but v3.4.1 will be used for PHP 5.5 because this is the latest supported version)
* Remove `cache: apt` because it's not supported (see https://github.com/travis-ci/travis-ci/issues/5876#issuecomment-207661127)
* Switch to Ubuntu Xenial instead of Trusty (but Trusty will be used for PHP 5.5)

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
