### PR TITLE
Run from current dir as default instead of root. Issue #1329

### DIFF
--- a/scripts/Phalcon/Commands/Builtin/Project.php
+++ b/scripts/Phalcon/Commands/Builtin/Project.php
@@ -63,7 +63,7 @@ class Project extends Command
     {
         $projectName    = $this->getOption(['name', 1], null, 'default');
         $projectType    = $this->getOption(['type', 2], null, 'simple');
-        $projectPath    = $this->getOption(['directory', 3]);
+        $projectPath    = $this->getOption(['directory', 3], null, ".");
         $templatePath   = $this->getOption(['template-path'], null, TEMPLATE_PATH);
         $enableWebtools = $this->getOption(['enable-webtools', 4], null, false);
         $useConfigIni   = $this->getOption('use-config-ini');


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #1329

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change: Set default install dir to current dir instead of '/'
[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
