### PR TITLE
Add missing server global variable for new router

### DIFF
--- a/templates/project/simple/router.php
+++ b/templates/project/simple/router.php
@@ -4,4 +4,4 @@ $router = $di->getRouter();
 
 // Define your routes here
 
-$router->handle();
+$router->handle($_SERVER["REQUEST_URI"]);


### PR DESCRIPTION
* Type: bug fix 
* Link to issue: https://github.com/phalcon/phalcon-devtools/issues/1374

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

The `router.php` file when running the `project` command is missing the `$_SERVER["REQUEST_URI"]` global variable in the `handle()` method as required in https://docs.phalcon.io/4.0/en/routing. I've added this variable to the `templates/project/simple/router.php` file and generated a new project with the `project` command. Error now gone and `router.php` file running as expected.