### PR TITLE
Import global vendor of Composer

### DIFF
--- a/bootstrap/autoload.php
+++ b/bootstrap/autoload.php
@@ -99,15 +99,21 @@ defined('COMPATIBLE_VERSION') || define('COMPATIBLE_VERSION', 3020040);
 /**
  * Register the Composer autoloader (if any)
  */
-$vendorAutoload = PTOOLSPATH . DS . 'vendor' . DS . 'autoload.php';
-if (!file_exists($vendorAutoload)) {
-    $vendorAutoload = PTOOLSPATH . DS . '..' . DS . '..' . DS . 'autoload.php';
-    if (!file_exists($vendorAutoload)) {
-        throw new Exception('Please run composer install');
+$vendorAutoload = [
+    PTOOLSPATH . DS . 'vendor' . DS . 'autoload.php', // Is installed locally
+    PTOOLSPATH . DS . '..' . DS . '..' . DS . 'autoload.php',  // Is installed via Composer
+];
+
+foreach ($vendorAutoload as $file) {
+    if (file_exists($file)) {
+        require_once $file;
+        break;
     }
 }
 
-require_once $vendorAutoload;
+if (false === class_exists('Composer\Autoload\ClassLoader', false)) {
+    throw new Exception('Please run composer install');
+}
 
 /**
  * Register the custom loader (if any)

--- a/bootstrap/autoload.php
+++ b/bootstrap/autoload.php
@@ -101,7 +101,10 @@ defined('COMPATIBLE_VERSION') || define('COMPATIBLE_VERSION', 3020040);
  */
 $vendorAutoload = PTOOLSPATH . DS . 'vendor' . DS . 'autoload.php';
 if (!file_exists($vendorAutoload)) {
-    throw new Exception('Please run composer install');
+    $vendorAutoload = PTOOLSPATH . DS . '..' . DS . '..' . DS . 'autoload.php';
+    if (!file_exists($vendorAutoload)) {
+        throw new Exception('Please run composer install');
+    }
 }
 
 require_once $vendorAutoload;


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue:  #1378 

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:
Check new path for autoload. This path is useful when you install phalcon-devtools with composer in global or local way.
If the path exists, I update the variable $vendorAutoload to load the correct file.

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
