### PR TITLE
Fix deprecated errors (compiled*)

### DIFF
--- a/templates/project/simple/services.php
+++ b/templates/project/simple/services.php
@@ -47,8 +47,8 @@ $di->setShared('view', function () {
             $volt = new VoltEngine($view, $this);
 
             $volt->setOptions([
-                'compiledPath' => $config->application->cacheDir,
-                'compiledSeparator' => '_'
+                'path' => $config->application->cacheDir,
+                'separator' => '_'
             ]);
 
             return $volt;


### PR DESCRIPTION
Hello!

To use Volt with Phalcon v4, I updated two Volt options :
`compiledPath` -> `path`
and
`compiledSeparator` -> `separator`

* Type: bug fix
* Link to issue: #1380 

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
