### PR TITLE
fix: added cli/launcher.bat and add changelog #1440

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# [4.0.2](https://github.com/phalcon/cphalcon/releases/tag/v4.0.2) (2020-xx-xx)
+## Added
+- Added launcher.bat to run cli with Windows and used DIRECTORY_SEPARATOR to find the file. [#1440](https://github.com/phalcon/phalcon-devtools/issues/1440) [@jenovateurs](https://github.com/jenovateurs)
+## Changed
+
+## Fixed
+- Fixed Scaffold templates errors and phpstan errors. [#1429](https://github.com/phalcon/phalcon-devtools/issues/1429) [@jenovateurs](https://github.com/jenovateurs)

--- a/src/Builder/Project/Cli.php
+++ b/src/Builder/Project/Cli.php
@@ -60,13 +60,20 @@ class Cli extends ProjectBuilder
      */
     private function createLauncher()
     {
-        $getFile = $this->options->get('templatePath') . '/project/cli/launcher';
+        $getFile = $this->options->get('templatePath') .
+            DIRECTORY_SEPARATOR . 'project' .
+            DIRECTORY_SEPARATOR . 'cli' .
+            DIRECTORY_SEPARATOR . 'launcher';
+
         $putFile = $this->options->get('projectPath') . 'run';
         $this->generateFile($getFile, $putFile);
         chmod($putFile, 0755);
 
         if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
-            $getFile = $this->options->get('templatePath') . '/project/cli/launcher.bat';
+            $getFile = $this->options->get('templatePath') .
+                DIRECTORY_SEPARATOR . 'project' .
+                DIRECTORY_SEPARATOR . 'cli' .
+                DIRECTORY_SEPARATOR . 'launcher.bat';
             $putFile = $this->options->get('projectPath') . 'run.bat';
             $this->generateFile($getFile, $putFile);
         }

--- a/templates/project/cli/launcher.bat
+++ b/templates/project/cli/launcher.bat
@@ -1,4 +1,4 @@
 @echo off
 
 set CURRENT_PATH=%~dp0
-php %CURRENT_PATH%launcher
+php %CURRENT_PATH%run


### PR DESCRIPTION
Hello team!
I added the launcher.bat file that missing for Windows.
I changed / to DIRECTORY_SEPARATOR.
In the launcher.bat files, I changed the name PATH to CURRENT_PATH. Windows use PATH to know where php is locate so it's very important to not override this variable.
I added a changelog, it will be useful when release a new version.

* Type: bug fix
* Link to issue: #1440 

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Thanks for the review :-)

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
