### PR TITLE
fix: #1410 - webtools not enabled by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
 - Fixed include order of files in created project [#1417](https://github.com/phalcon/phalcon-devtools/issues/1417)
 - Fixed Scaffold templates errors and phpstan errors. [#1429](https://github.com/phalcon/phalcon-devtools/issues/1429) [@jenovateurs](https://github.com/jenovateurs)
 - Fixed duplicate camelCase properties [#1433](https://github.com/phalcon/phalcon-devtools/pull/1433)
+- Fixed webtools not enabled by default when creating a new project [#1410](https://github.com/phalcon/phalcon-devtools/issues/1410) [@jenovateurs](https://github.com/jenovateurs)

--- a/src/Builder/Project/Simple.php
+++ b/src/Builder/Project/Simple.php
@@ -58,6 +58,7 @@ class Simple extends ProjectBuilder
      */
     public function build()
     {
+        
         $this
             ->buildDirectories()
             ->getVariableValues()
@@ -69,7 +70,7 @@ class Simple extends ProjectBuilder
             ->createControllerFile()
             ->createHtrouterFile();
 
-        if ($this->options->has('enableWebTools')) {
+        if ($this->options->has('enableWebTools') && true === $this->options->enableWebTools) {
             Tools::install($this->options->get('projectPath'));
         }
 

--- a/tests/console/GenerateProjectCept.php
+++ b/tests/console/GenerateProjectCept.php
@@ -64,3 +64,27 @@ $I->runShellCommand('phalcon project ' . $projectName4 . ' simple --template-eng
 $I->seeFileFound(app_path($path4));
 $I->seeFileFound(app_path($path4 . '/app/views/index.volt'));
 $I->deleteDir(app_path($path4));
+
+/** 
+ * Case 5 - Check webtools is disable by default
+ */
+$projectName5 = 'webtools_defaults';
+$path5 = $projectsFolder . '/' . $projectName5;
+
+$I->dontSeeFileFound(app_path($path5));
+$I->runShellCommand('phalcon project ' . $projectName5);
+$I->dontSeeFileFound(app_path($path5 . '/public/webtools.php'));
+$I->dontSeeFileFound(app_path($path5 . '/public/webtools.config.php'));
+$I->deleteDir(app_path($path5));
+
+/** 
+ * Case 6 - Check webtools file when it's activated
+ */
+$projectName6 = 'webtools_activated';
+$path6 = $projectsFolder . '/' . $projectName6;
+
+$I->dontSeeFileFound(app_path($path6));
+$I->runShellCommand('phalcon project ' . $projectName6 . '--enable-webtools');
+$I->seeFileFound(app_path($path6 . '/public/webtools.php'));
+$I->seeFileFound(app_path($path6 . '/public/webtools.config.php'));
+$I->deleteDir(app_path($path6));

--- a/tests/console/GenerateProjectCept.php
+++ b/tests/console/GenerateProjectCept.php
@@ -84,7 +84,7 @@ $projectName6 = 'webtools_activated';
 $path6 = $projectsFolder . '/' . $projectName6;
 
 $I->dontSeeFileFound(app_path($path6));
-$I->runShellCommand('phalcon project ' . $projectName6 . '--enable-webtools');
+$I->runShellCommand('phalcon project ' . $projectName6 . ' --enable-webtools');
 $I->seeFileFound(app_path($path6 . '/public/webtools.php'));
 $I->seeFileFound(app_path($path6 . '/public/webtools.config.php'));
 $I->deleteDir(app_path($path6));

--- a/tests/console/GenerateProjectCept.php
+++ b/tests/console/GenerateProjectCept.php
@@ -65,7 +65,7 @@ $I->seeFileFound(app_path($path4));
 $I->seeFileFound(app_path($path4 . '/app/views/index.volt'));
 $I->deleteDir(app_path($path4));
 
-/** 
+/**
  * Case 5 - Check webtools is disable by default
  */
 $projectName5 = 'webtools_defaults';
@@ -77,7 +77,7 @@ $I->dontSeeFileFound(app_path($path5 . '/public/webtools.php'));
 $I->dontSeeFileFound(app_path($path5 . '/public/webtools.config.php'));
 $I->deleteDir(app_path($path5));
 
-/** 
+/**
  * Case 6 - Check webtools file when it's activated
  */
 $projectName6 = 'webtools_activated';


### PR DESCRIPTION
Hello team!

By default webtools is no more activated by default.
And I made a two tests to check it.
One to check that without --enable-webtools, there are no webtools files.
With --enable-webtools, I check, if the files webtools.php and webtools.config.php are in the folder.

* Type: bug fix
* Link to issue: #1410

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR


Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
