### PR TITLE
Generated models::findFirst doesnt have a return type

### DIFF
--- a/src/Generator/Snippet.php
+++ b/src/Generator/Snippet.php
@@ -265,9 +265,9 @@ EOD;
      * Allows to query the first record that match the specified conditions
      *
      * @param mixed \$parameters
-     * @return %s|\Phalcon\Mvc\Model\ResultInterface
+     * @return %s|null
      */
-    public static function findFirst(\$parameters = null)
+    public static function findFirst(\$parameters = null): ?\Phalcon\Mvc\ModelInterface
     {
         return parent::findFirst(\$parameters);
     }


### PR DESCRIPTION
Hello!

* Type: bug fix

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:

when generating a new model the ```findFirst``` method doesn't have a return type and results in a fatal error

>PHP Fatal error:  Declaration of TestModel::findFirst($parameters = NULL) must be compatible with Phalcon\Mvc\Model::findFirst($parameters = NULL): ?Phalcon\Mvc\ModelInterface

fixed with adding return type compatible with Phalcon\Mvc\Model::findFirst

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
