### PR TITLE
vlucas/phpdotenv dependency compatibility upgrade

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
         name: PHP ${{ matrix.php-versions }}
         runs-on: ubuntu-latest
         env:
-            extensions: mbstring, intl, json, phalcon-4.0.5, mysql, pgsql, xdebug
+            extensions: mbstring, intl, json, zip, phalcon-4.0.5, mysql, pgsql, xdebug
             key: cache-v2.0~19.03.2020
         services:
             mysql:

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "psy/psysh": "~0.9",
         "nikic/php-parser": "^4.2.4",
         "phalcon/migrations": "^1.1",
-        "vlucas/phpdotenv": "^3.6"
+        "vlucas/phpdotenv": "^3.6|^4.0|^5.0"
     },
     "require-dev": {
         "humbug/box": "^3.8",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
         "squizlabs/php_codesniffer": "^3.5",
         "phalcon/ide-stubs": "^4.0.0",
         "vimeo/psalm": "^3.7",
-        "codeception/module-phpbrowser": "^1.0"
+        "codeception/module-phpbrowser": "^1.0",
+        "codeception/module-filesystem": "^1.0"
     },
     "autoload": {
         "psr-4" : {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "require-dev": {
         "humbug/box": "^3.8",
-        "codeception/codeception": "^3.1",
+        "codeception/codeception": "^4.1",
         "phpdocumentor/reflection-docblock": "^4.3",
         "phpunit/phpunit": "^8.0",
         "codeception/specify": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
         "codeception/verify": "^1.2",
         "squizlabs/php_codesniffer": "^3.5",
         "phalcon/ide-stubs": "^4.0.0",
-        "vimeo/psalm": "^3.7"
+        "vimeo/psalm": "^3.7",
+        "codeception/module-phpbrowser": "^1.0"
     },
     "autoload": {
         "psr-4" : {


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: https://github.com/phalcon/phalcon-devtools/issues/1460

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:

Upgrade `vlucas/phpdotenv` dependency version to be compatible with newest major releases.
