### PR TITLE
Fix/issue 1426 windows config path matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## Fixed
 - Fixed model creation failure in webtools due to wrong variable mutation [#1415](https://github.com/phalcon/phalcon-devtools/issues/1415)
+- Fixed config path detection to platform independent [#1426](https://github.com/phalcon/phalcon-devtools/issues/1426)
 
 ## Changed
 

--- a/src/Builder/Path.php
+++ b/src/Builder/Path.php
@@ -43,34 +43,32 @@ class Path
         $type  = isset($types[$type]) ? $type : 'ini';
 
         foreach (['app/config/', 'config/', 'apps/config/', 'apps/frontend/config/'] as $configPath) {
-            if ('ini' == $type && file_exists($this->rootPath . $configPath . 'config.ini')) {
+            if ('ini' === $type && file_exists($this->rootPath . $configPath . 'config.ini')) {
                 return new ConfigIni($this->rootPath . $configPath . 'config.ini');
-            } else {
-                if (file_exists($this->rootPath . $configPath. 'config.php')) {
-                    $config = include($this->rootPath . $configPath . 'config.php');
-                    if (is_array($config)) {
-                        $config = new Config($config);
-                    }
-
-                    return $config;
+            }
+            if (file_exists($this->rootPath . $configPath. 'config.php')) {
+                $config = include($this->rootPath . $configPath . 'config.php');
+                if (is_array($config)) {
+                    $config = new Config($config);
                 }
+
+                return $config;
             }
         }
 
         $directory = new RecursiveDirectoryIterator('.');
         $iterator = new RecursiveIteratorIterator($directory);
         foreach ($iterator as $f) {
-            if (preg_match('/\/config\.php$/i', $f->getPathName())) {
+            if (false !== strpos($f->getPathName(), 'config.php')) {
                 $config = include $f->getPathName();
                 if (is_array($config)) {
                     $config = new Config($config);
                 }
 
                 return $config;
-            } else {
-                if (preg_match('/config\.ini$/i', $f->getPathName())) {
-                    return new ConfigIni($f->getPathName());
-                }
+            }
+            if (false !== strpos($f->getPathName(), 'config.ini')) {
+                return new ConfigIni($f->getPathName());
             }
         }
 


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: [#1426](https://github.com/phalcon/phalcon-devtools/issues/1426)

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:
Regex matching is overhead in just searching filename in path string. Which causes platform dependent issues.
Replaced preg_match in config file comparison by strpos.  

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
