### PR TITLE
ISSUE-1297: Removed getSource() method due to final implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Fixed optional options (namespace, abstract) checks on model create [#1491](https://github.com/phalcon/phalcon-devtools/issues/1491)
 - Fixed wrong request filtering [#1468](https://github.com/phalcon/phalcon-devtools/issues/1468)
 - Fixed empty namespace generation [#1467](https://github.com/phalcon/phalcon-devtools/issues/1467)
+- Removed `model->getSource()` method generation due to its becoming final in `Phalcon\Mvc\Model` [#1297](https://github.com/phalcon/phalcon-devtools/issues/1297)
+
 
 # [4.0.5](https://github.com/phalcon/cphalcon/releases/tag/v4.0.5) (2021-03-14)
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Fixed
 - Fixed model findFirst return type error [#1478](https://github.com/phalcon/phalcon-devtools/issues/1478)
 - Added trailing semicolon to scaffolding crud views getters [#1477](https://github.com/phalcon/phalcon-devtools/issues/1477)
+- Fixed optional options (namespace, abstract) checks on model create [#1491](https://github.com/phalcon/phalcon-devtools/issues/1491)
 
 # [4.0.5](https://github.com/phalcon/cphalcon/releases/tag/v4.0.5) (2021-03-14)
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fixed model findFirst return type error [#1478](https://github.com/phalcon/phalcon-devtools/issues/1478)
 - Added trailing semicolon to scaffolding crud views getters [#1477](https://github.com/phalcon/phalcon-devtools/issues/1477)
 - Fixed optional options (namespace, abstract) checks on model create [#1491](https://github.com/phalcon/phalcon-devtools/issues/1491)
+- Fixed wrong request filtering [#1468](https://github.com/phalcon/phalcon-devtools/issues/1468)
 
 # [4.0.5](https://github.com/phalcon/cphalcon/releases/tag/v4.0.5) (2021-03-14)
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added trailing semicolon to scaffolding crud views getters [#1477](https://github.com/phalcon/phalcon-devtools/issues/1477)
 - Fixed optional options (namespace, abstract) checks on model create [#1491](https://github.com/phalcon/phalcon-devtools/issues/1491)
 - Fixed wrong request filtering [#1468](https://github.com/phalcon/phalcon-devtools/issues/1468)
+- Fixed empty namespace generation [#1467](https://github.com/phalcon/phalcon-devtools/issues/1467)
 
 # [4.0.5](https://github.com/phalcon/cphalcon/releases/tag/v4.0.5) (2021-03-14)
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [4.0.6](https://github.com/phalcon/cphalcon/releases/tag/v4.0.6)
+## Fixed
+- Fixed model findFirst return type error [#1478](https://github.com/phalcon/phalcon-devtools/issues/1478)
+
 # [4.0.5](https://github.com/phalcon/cphalcon/releases/tag/v4.0.5) (2021-03-14)
 ## Fixed
 - Fixed model creation failure in webtools due to wrong variable mutation [#1415](https://github.com/phalcon/phalcon-devtools/issues/1415)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [4.0.6](https://github.com/phalcon/cphalcon/releases/tag/v4.0.6)
 ## Fixed
 - Fixed model findFirst return type error [#1478](https://github.com/phalcon/phalcon-devtools/issues/1478)
+- Added trailing semicolon to scaffolding crud views getters [#1477](https://github.com/phalcon/phalcon-devtools/issues/1477)
 
 # [4.0.5](https://github.com/phalcon/cphalcon/releases/tag/v4.0.5) (2021-03-14)
 ## Fixed

--- a/src/Builder/Component/Controller.php
+++ b/src/Builder/Component/Controller.php
@@ -103,12 +103,14 @@ class Controller extends AbstractComponent
      */
     protected function constructNamespace(): string
     {
-        $namespace = $this->options->get('namespace');
+        $namespace = $this->options->has('namespace')
+            ? (string) $this->options->get('namespace') : null;
+
         if ($namespace === null) {
             return '';
         }
 
-        if ($this->checkNamespace((string)$namespace)) {
+        if ($this->checkNamespace($namespace) && !empty(trim($namespace))) {
             return 'namespace ' . $this->options->get('namespace') . ';' . PHP_EOL . PHP_EOL;
         }
 

--- a/src/Builder/Component/Model.php
+++ b/src/Builder/Component/Model.php
@@ -226,8 +226,6 @@ class Model extends AbstractComponent
                     }
                 }
 
-                $possibleMethods['getSource'] = true;
-
                 /** @noinspection PhpIncludeInspection */
                 require_once $modelPath;
 

--- a/src/Builder/Component/Model.php
+++ b/src/Builder/Component/Model.php
@@ -172,7 +172,7 @@ class Model extends AbstractComponent
                 }
 
                 $entityNamespace = '';
-                if ($this->modelOptions->getOption('namespace')) {
+                if ($this->modelOptions->hasOption('namespace')) {
                     $entityNamespace = $this->modelOptions->getOption('namespace')."\\";
                 }
 
@@ -190,7 +190,7 @@ class Model extends AbstractComponent
 
         foreach ($db->describeReferences($this->modelOptions->getOption('name'), $schema) as $reference) {
             $entityNamespace = '';
-            if ($this->modelOptions->getOption('namespace')) {
+            if ($this->modelOptions->hasOption('namespace')) {
                 $entityNamespace = $this->modelOptions->getOption('namespace');
             }
 

--- a/src/Builder/Component/Model.php
+++ b/src/Builder/Component/Model.php
@@ -111,9 +111,10 @@ class Model extends AbstractComponent
             require_once $config->devtools->loader;
         }
 
-        $namespace = '';
-        if ($this->modelOptions->hasOption('namespace') &&
-            $this->checkNamespace((string)$this->modelOptions->getOption('namespace'))) {
+        $namespace = $this->modelOptions->hasOption('namespace')
+            ? (string) $this->modelOptions->getOption('namespace') : '';
+
+        if ($this->checkNamespace($namespace) && !empty(trim($namespace))) {
             $namespace = 'namespace ' . $this->modelOptions->getOption('namespace') . ';' . PHP_EOL . PHP_EOL;
         }
 

--- a/src/Builder/Component/Scaffold.php
+++ b/src/Builder/Component/Scaffold.php
@@ -309,33 +309,33 @@ class Scaffold extends AbstractComponent
             $code .= "\t\t" . '<?php echo $this->tag->select(["' . $attribute . '", $' .
                 $selectDefinition[$attribute]['varName'] . ', "using" => "' .
                 $selectDefinition[$attribute]['primaryKey'] . ',' . $selectDefinition[$attribute]['detail'] .
-                '", "useDummy" => true), "class" => "form-control", "id" => "' . $id . '"] ?>';
+                '", "useDummy" => true), "class" => "form-control", "id" => "' . $id . '"]; ?>';
         } else {
             switch ($dataType) {
                 case Column::TYPE_ENUM: // enum
                     $code .= "\t\t" . '<?php echo $this->tag->selectStatic(["' . $attribute .
-                        '", [], "class" => "form-control", "id" => "' . $id . '"]) ?>';
+                        '", [], "class" => "form-control", "id" => "' . $id . '"]); ?>';
                     break;
                 case Column::TYPE_CHAR:
                     $code .=  "\t\t" . '<?php echo $this->tag->textField(["' . $attribute .
-                        '", "class" => "form-control", "id" => "' . $id . '"]) ?>';
+                        '", "class" => "form-control", "id" => "' . $id . '"]); ?>';
                     break;
                 case Column::TYPE_DECIMAL:
                 case Column::TYPE_INTEGER:
                     $code .= "\t\t" . '<?php echo $this->tag->textField(["' . $attribute .
-                        '", "type" => "number", "class" => "form-control", "id" => "' . $id . '"]) ?>';
+                        '", "type" => "number", "class" => "form-control", "id" => "' . $id . '"]); ?>';
                     break;
                 case Column::TYPE_DATE:
                     $code .= "\t\t" . '<?php echo $this->tag->textField(["' . $attribute .
-                        '", "type" => "date", "class" => "form-control", "id" => "' . $id . '"]) ?>';
+                        '", "type" => "date", "class" => "form-control", "id" => "' . $id . '"]); ?>';
                     break;
                 case Column::TYPE_TEXT:
                     $code .= "\t\t" . '<?php echo $this->tag->textArea(["' . $attribute .
-                        '", "cols" => 30, "rows" => 4, "class" => "form-control", "id" => "' . $id . '"]) ?>';
+                        '", "cols" => 30, "rows" => 4, "class" => "form-control", "id" => "' . $id . '"]); ?>';
                     break;
                 default:
                     $code .= "\t\t" . '<?php echo $this->tag->textField(["' . $attribute .
-                        '", "size" => 30, "class" => "form-control", "id" => "' . $id . '"]) ?>';
+                        '", "size" => 30, "class" => "form-control", "id" => "' . $id . '"]); ?>';
                     break;
             }
         }
@@ -565,8 +565,8 @@ class Scaffold extends AbstractComponent
             // View model layout
             $code = '';
             if ($this->options->has('theme')) {
-                $code .= '<?php $this->tag->stylesheetLink("themes/lightness/style") ?>'.PHP_EOL;
-                $code .= '<?php $this->tag->stylesheetLink("themes/base") ?>'.PHP_EOL;
+                $code .= '<?php $this->tag->stylesheetLink("themes/lightness/style"); ?>'.PHP_EOL;
+                $code .= '<?php $this->tag->stylesheetLink("themes/base"); ?>'.PHP_EOL;
                 $code .= '<div class="ui-layout" align="center">' . PHP_EOL;
             } else {
                 $code .= '<div class="center-block">' . PHP_EOL;
@@ -733,9 +733,9 @@ class Scaffold extends AbstractComponent
             } else {
                 $detailField = ucfirst($this->options->get('allReferences')[$fieldName]['detail']);
                 $rowCode .= '$' . $this->options->get('singular') . '->get' .
-                    $this->options->get('allReferences')[$fieldName]['tableName'] . '()->get' . $detailField . '()';
+                    $this->options->get('allReferences')[$fieldName]['tableName'] . '()->get' . $detailField . '();';
             }
-            $rowCode .= ' ?></td>' . PHP_EOL;
+            $rowCode .= '; ?></td>' . PHP_EOL;
         }
 
         $idField =  $this->options->get('attributes')[0];

--- a/src/Builder/Component/Scaffold.php
+++ b/src/Builder/Component/Scaffold.php
@@ -459,14 +459,13 @@ class Scaffold extends AbstractComponent
         $code = file_get_contents($this->options->get('templatePath') . '/scaffold/no-forms/Controller.php');
         $usesNamespaces = false;
 
-        $controllerNamespace = (string)$this->options->get('controllersNamespace');
-        if ($this->options->has('controllersNamespace') &&
-            $controllerNamespace &&
-            $this->checkNamespace($controllerNamespace)
-        ) {
+        $controllerNamespace = $this->options->has('controllersNamespace')
+            ? (string) $this->options->get('controllersNamespace') : '';
+
+        if (!empty(trim($controllerNamespace)) && $this->checkNamespace($controllerNamespace)) {
             $code = str_replace(
                 '$namespace$',
-                'namespace ' . $this->options->get('controllersNamespace').';' . PHP_EOL,
+                'namespace ' . $controllerNamespace.';' . PHP_EOL,
                 $code
             );
             $usesNamespaces = true;

--- a/src/Builder/Component/Scaffold.php
+++ b/src/Builder/Component/Scaffold.php
@@ -183,7 +183,7 @@ class Scaffold extends AbstractComponent
         $attributes = $metaData->getAttributes($entity);
         $dataTypes = $metaData->getDataTypes($entity);
         $identityField = $metaData->getIdentityField($entity);
-        $identityField = $identityField ? $identityField : null;
+        $identityField = $identityField ?: null;
         $primaryKeys = $metaData->getPrimaryKeyAttributes($entity);
 
         $setParams = [];
@@ -210,7 +210,7 @@ class Scaffold extends AbstractComponent
         // Build Controller
         $this->makeController();
 
-        if ($this->options->get('templateEngine') == 'volt') {
+        if ($this->options->get('templateEngine') === 'volt') {
             $this->makeLayoutsVolt();
             $this->makeViewVolt('index');
             $this->makeViewSearchVolt();
@@ -233,7 +233,7 @@ class Scaffold extends AbstractComponent
      * @param string $var
      * @param mixed $fields
      * @param bool $useGetSetters
-     * @param string $identityField
+     * @param null|string $identityField
      *
      * @return string
      */
@@ -241,18 +241,16 @@ class Scaffold extends AbstractComponent
     {
         $code = '';
         foreach ($fields as $field => $dataType) {
-            if ($identityField !== null && $field == $identityField) {
+            if ($identityField !== null && $field === $identityField) {
                 continue;
             }
 
-            if (is_int($dataType) !== false) {
+            if (\in_array($dataType, [Column::TYPE_DECIMAL, Column::TYPE_INTEGER])) {
                 $fieldCode = '$this->request->getPost("'.$field.'", "int")';
+            } elseif ($field === 'email') {
+                $fieldCode = '$this->request->getPost("'.$field.'", "email")';
             } else {
-                if ($field == 'email') {
-                    $fieldCode = '$this->request->getPost("'.$field.'", "email")';
-                } else {
-                    $fieldCode = '$this->request->getPost("'.$field.'")';
-                }
+                $fieldCode = '$this->request->getPost("'.$field.'")';
             }
 
             $code .= '$' . Utils::lowerCamelizeWithDelimiter($var, '-', true) . '->';

--- a/src/Generator/Snippet.php
+++ b/src/Generator/Snippet.php
@@ -265,9 +265,9 @@ EOD;
      * Allows to query the first record that match the specified conditions
      *
      * @param mixed \$parameters
-     * @return %s|\Phalcon\Mvc\Model\ResultInterface
+     * @return %s|\Phalcon\Mvc\Model\ResultInterface|\Phalcon\Mvc\ModelInterface|null
      */
-    public static function findFirst(\$parameters = null)
+    public static function findFirst(\$parameters = null): ?\Phalcon\Mvc\ModelInterface
     {
         return parent::findFirst(\$parameters);
     }

--- a/tests/_data/console/app/models/files/TestModel.php
+++ b/tests/_data/console/app/models/files/TestModel.php
@@ -57,9 +57,9 @@ class TestModel extends \Phalcon\Mvc\Model
      * Allows to query the first record that match the specified conditions
      *
      * @param mixed $parameters
-     * @return TestModel|\Phalcon\Mvc\Model\ResultInterface
+     * @return TestModel|\Phalcon\Mvc\Model\ResultInterface|\Phalcon\Mvc\ModelInterface|null
      */
-    public static function findFirst($parameters = null)
+    public static function findFirst($parameters = null): ?\Phalcon\Mvc\ModelInterface
     {
         return parent::findFirst($parameters);
     }

--- a/tests/_data/console/app/models/files/TestModel2.php
+++ b/tests/_data/console/app/models/files/TestModel2.php
@@ -43,9 +43,9 @@ class TestModel2 extends \Phalcon\Mvc\Model
      * Allows to query the first record that match the specified conditions
      *
      * @param mixed $parameters
-     * @return TestModel2|\Phalcon\Mvc\Model\ResultInterface
+     * @return TestModel2|\Phalcon\Mvc\Model\ResultInterface|\Phalcon\Mvc\ModelInterface|null
      */
-    public static function findFirst($parameters = null)
+    public static function findFirst($parameters = null): ?\Phalcon\Mvc\ModelInterface
     {
         return parent::findFirst($parameters);
     }

--- a/tests/_data/console/app/models/files/TestModel3.php
+++ b/tests/_data/console/app/models/files/TestModel3.php
@@ -43,9 +43,9 @@ class TestModel3 extends \Phalcon\Mvc\Model
      * Allows to query the first record that match the specified conditions
      *
      * @param mixed $parameters
-     * @return TestModel3|\Phalcon\Mvc\Model\ResultInterface
+     * @return TestModel3|\Phalcon\Mvc\Model\ResultInterface|\Phalcon\Mvc\ModelInterface|null
      */
-    public static function findFirst($parameters = null)
+    public static function findFirst($parameters = null): ?\Phalcon\Mvc\ModelInterface
     {
         return parent::findFirst($parameters);
     }

--- a/tests/_data/console/app/models/files/TestModel5.php
+++ b/tests/_data/console/app/models/files/TestModel5.php
@@ -28,22 +28,12 @@ class TestModel5 extends \Phalcon\Mvc\Model
     }
 
     /**
-     * Returns table name mapped in the model.
-     *
-     * @return string
-     */
-    public function getSource()
-    {
-        return 'TestModel5';
-    }
-
-    /**
      * Allows to query a set of records that match the specified conditions
      *
      * @param mixed $parameters
      * @return TestModel5[]|TestModel5|\Phalcon\Mvc\Model\ResultSetInterface
      */
-    public static function find($parameters = null)
+    public static function find($parameters = null): \Phalcon\Mvc\Model\ResultsetInterface
     {
         return parent::find($parameters);
     }
@@ -52,9 +42,9 @@ class TestModel5 extends \Phalcon\Mvc\Model
      * Allows to query the first record that match the specified conditions
      *
      * @param mixed $parameters
-     * @return TestModel5|\Phalcon\Mvc\Model\ResultInterface
+     * @return TestModel5|\Phalcon\Mvc\Model\ResultInterface|\Phalcon\Mvc\ModelInterface|null
      */
-    public static function findFirst($parameters = null)
+    public static function findFirst($parameters = null): ?\Phalcon\Mvc\ModelInterface
     {
         return parent::findFirst($parameters);
     }

--- a/tests/_data/console/app/models/files/Testmodel4.php
+++ b/tests/_data/console/app/models/files/Testmodel4.php
@@ -43,9 +43,9 @@ class Testmodel4 extends \Phalcon\Mvc\Model
      * Allows to query the first record that match the specified conditions
      *
      * @param mixed $parameters
-     * @return Testmodel4|\Phalcon\Mvc\Model\ResultInterface
+     * @return Testmodel4|\Phalcon\Mvc\Model\ResultInterface|\Phalcon\Mvc\ModelInterface|null
      */
-    public static function findFirst($parameters = null)
+    public static function findFirst($parameters = null): ?\Phalcon\Mvc\ModelInterface
     {
         return parent::findFirst($parameters);
     }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #1297 

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:
Removed getSource() method generation.
It became `final` in [phalcon/cphalcon#13950](https://github.com/phalcon/cphalcon/pull/13950)

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
