### PR TITLE
Fix #1506 config file locating issue

### DIFF
--- a/scripts/Phalcon/Builder/AllModels.php
+++ b/scripts/Phalcon/Builder/AllModels.php
@@ -56,7 +56,7 @@ class AllModels extends Component
 
     public function build()
     {
-        if ($this->options->offsetExists('directory')) {
+        if ($this->options->offsetExists('directory') && $this->options->get('directory') !== null) {
             $this->path->setRootPath($this->options->get('directory'));
         }
 

--- a/scripts/Phalcon/Builder/Controller.php
+++ b/scripts/Phalcon/Builder/Controller.php
@@ -58,7 +58,7 @@ class Controller extends Component
      */
     public function build()
     {
-        if ($this->options->offsetExists('directory')) {
+        if ($this->options->offsetExists('directory') && $this->options->get('directory') !== null) {
             $this->path->setRootPath($this->options->get('directory'));
         }
 

--- a/scripts/Phalcon/Builder/Module.php
+++ b/scripts/Phalcon/Builder/Module.php
@@ -74,7 +74,7 @@ class Module extends Component
                 . 'templates' . DIRECTORY_SEPARATOR . 'module';
         }
 
-        if ($this->options->offsetExists('directory')) {
+        if ($this->options->offsetExists('directory') && $this->options->get('directory') !== null) {
             $this->path->setRootPath($this->options->get('directory'));
         }
 

--- a/scripts/Phalcon/Builder/Project.php
+++ b/scripts/Phalcon/Builder/Project.php
@@ -66,7 +66,7 @@ class Project extends Component
      */
     public function build()
     {
-        if ($this->options->offsetExists('directory')) {
+        if ($this->options->offsetExists('directory') && $this->options->get('directory') !== null) {
             $this->path->setRootPath($this->options->get('directory'));
         }
 


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/phalcon-devtools/issues/1506

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:

Fixes issue where
```
phalcon create-controller --name test
```
defaults to NULL as the directory where it searches for the config.php file in the wrong place, `/`, upon not finding it, the code falls back to a recursive directory search logic which then finds the `public/webtools.config.php` file and loads up the wrong config file causing an error:
> PHP Fatal error:  Uncaught Error: Call to a member function path() on int in /var/www/repos/phalcon-devtools/scripts/Phalcon/Builder/Controller.php:74
Stack trace:
#0 /var/www/repos/phalcon-devtools/scripts/Phalcon/Commands/Builtin/Controller.php(74): Phalcon\Builder\Controller->build()
#1 /var/www/repos/phalcon-devtools/scripts/Phalcon/Script.php(117): Phalcon\Commands\Builtin\Controller->run(Array)
#2 /var/www/repos/phalcon-devtools/scripts/Phalcon/Script.php(151): Phalcon\Script->dispatch(Object(Phalcon\Commands\Builtin\Controller))
#3 /var/www/repos/phalcon-devtools/phalcon(76): Phalcon\Script->run()
#4 {main}
  thrown in /var/www/repos/phalcon-devtools/scripts/Phalcon/Builder/Controller.php on line 74

This can be worked around with:
```
phalcon create-controller --name test --directory .
```
but the code should not error when not specifying a directory.

Thanks
