### PR TITLE
Fix #1479 more verbose pdo driver missing errors for 3.4.x

### DIFF
--- a/phalcon
+++ b/phalcon
@@ -37,8 +37,10 @@ use Phalcon\Commands\Builtin\Controller;
 use Phalcon\Commands\Builtin\Serve;
 use Phalcon\Commands\Builtin\Console;
 use Phalcon\Exception as PhalconException;
+use Phalcon\Exception\Db\PDODriverNotFoundException;
 use Phalcon\Commands\DotPhalconMissingException;
 use Phalcon\Events\Manager as EventsManager;
+
 
 try {
     require dirname(__FILE__) . '/bootstrap/autoload.php';
@@ -83,6 +85,11 @@ try {
     }
 } catch (PhalconException $e) {
     fwrite(STDERR, Color::error($e->getMessage()) . PHP_EOL);
+    exit(1);
+} catch (PDODriverNotFoundException $e) {
+    $e->writeNicelyFormattedErrorOutput();
+    fwrite(STDERR, 'Backtrace:'. PHP_EOL);
+    fwrite(STDERR, $e->getTraceAsString() . PHP_EOL);
     exit(1);
 } catch (Exception $e) {
     fwrite(STDERR, 'ERROR: ' . $e->getMessage() . PHP_EOL);

--- a/scripts/Phalcon/Exception/Db/PDODriverNotFoundException.php
+++ b/scripts/Phalcon/Exception/Db/PDODriverNotFoundException.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+  +------------------------------------------------------------------------+
+  | Phalcon Developer Tools                                                |
+  +------------------------------------------------------------------------+
+  | Copyright (c) 2011-present Phalcon Team (https://www.phalconphp.com)   |
+  +------------------------------------------------------------------------+
+  | This source file is subject to the New BSD License that is bundled     |
+  | with this package in the file LICENSE.txt.                             |
+  |                                                                        |
+  | If you did not receive a copy of the license and are unable to         |
+  | obtain it through the world-wide-web, please send an email             |
+  | to license@phalconphp.com so we can send you a copy immediately.       |
+  +------------------------------------------------------------------------+
+  | Authors: Kevin Yarmak <ultimater@gmail.com>                            |
+  +------------------------------------------------------------------------+
+*/
+
+namespace Phalcon\Exception\Db;
+
+use PDOException;
+use Phalcon\Script\Color;
+use PDO;
+
+class PDODriverNotFoundException extends PDOException
+{
+    protected $adapter = '';
+
+    public function __construct($message, $adapter = '')
+    {
+        parent::__construct($message);
+        $this->adapter = $adapter;
+    }
+
+    public function getAdapter()
+    {
+        return $this->adapter;
+    }
+
+    public function writeNicelyFormattedErrorOutput()
+    {
+        fwrite(STDERR, Color::error($this->getMessage()) . PHP_EOL);
+
+        if (!extension_loaded('PDO')) {
+            fwrite(STDERR, Color::error('PDO extension is not loaded') . PHP_EOL);
+        } else {
+            $loadedDrivers = PDO::getAvailableDrivers();
+            fwrite(STDERR, 'PDO Drivers loaded:' . PHP_EOL);
+            fwrite(STDERR, print_r($loadedDrivers, true). PHP_EOL);
+        }
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: https://github.com/phalcon/phalcon-devtools/issues/1479

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:

If using a PDO driver such as Postgresql or Mysql, and it is not loaded when trying to go through the Phalcon adapter, PDO will error with the vague "could not find driver" which will leave developers on a quest to figure out what happened.

![old-error](https://user-images.githubusercontent.com/1922199/124580664-35939800-de05-11eb-8fbe-6aedda3d19e8.png)


This PR will fix the vague issue for 3.4.x and it will instead show a much more detailed error.

![new-error-msg](https://user-images.githubusercontent.com/1922199/124580772-50fea300-de05-11eb-8dd6-cfdeb9fa95ff.png)


Thanks

