### PR TITLE
Fix #1479 more verbose pdo driver missing errors for 4.0.x

### DIFF
--- a/phalcon
+++ b/phalcon
@@ -23,6 +23,7 @@ use Phalcon\DevTools\Commands\Builtin\Scaffold;
 use Phalcon\DevTools\Commands\Builtin\Serve;
 use Phalcon\DevTools\Commands\Builtin\Webtools;
 use Phalcon\DevTools\Commands\CommandsListener;
+use Phalcon\DevTools\Exception\PDODriverNotFoundException;
 use Phalcon\DevTools\Commands\DotPhalconMissingException;
 use Phalcon\DevTools\Script;
 use Phalcon\DevTools\Script\Color;
@@ -71,6 +72,11 @@ try {
     }
 } catch (PhalconException $e) {
     fwrite(STDERR, Color::error($e->getMessage()) . PHP_EOL);
+    exit(1);
+} catch (PDODriverNotFoundException $e) {
+    $e->writeNicelyFormattedErrorOutput();
+    fwrite(STDERR, 'Backtrace:'. PHP_EOL);
+    fwrite(STDERR, $e->getTraceAsString() . PHP_EOL);
     exit(1);
 } catch (Exception $e) {
     fwrite(STDERR, 'ERROR: ' . $e->getMessage() . PHP_EOL);

--- a/src/Builder/Component/Model.php
+++ b/src/Builder/Component/Model.php
@@ -20,6 +20,7 @@ use Phalcon\DevTools\Exception\InvalidArgumentException;
 use Phalcon\DevTools\Exception\InvalidParameterException;
 use Phalcon\DevTools\Exception\RuntimeException;
 use Phalcon\DevTools\Exception\WriteFileException;
+use Phalcon\DevTools\Exception\PDODriverNotFoundException;
 use Phalcon\DevTools\Generator\Snippet;
 use Phalcon\DevTools\Options\OptionsAware as ModelOption;
 use Phalcon\DevTools\Utils;
@@ -29,6 +30,7 @@ use Phalcon\Validation\Validator\Email as EmailValidator;
 use ReflectionClass;
 use ReflectionClassConstant;
 use ReflectionProperty;
+use PDOException;
 
 /**
  * Builder to generate models
@@ -138,9 +140,18 @@ class Model extends AbstractComponent
         $adapterName = 'Phalcon\Db\Adapter\Pdo\\' . $adapter;
         unset($configArray['adapter']);
 
-        /** @var AbstractPdo $db */
-        $db = new $adapterName($configArray);
-
+        try {
+            /** @var AbstractPdo $db */
+            $db = new $adapterName($configArray);
+        } catch (PDOException $e) {
+            switch ($e->getMessage()) {
+                case 'could not find driver':
+                    throw new PDODriverNotFoundException("PDO could not find driver $adapter", $adapter);
+                    break;
+                default:
+                    throw new PDOException($e->getMessage());
+            }
+        }
         $initialize = [];
 
         if ($this->modelOptions->hasOption('schema')) {

--- a/src/Exception/PDODriverNotFoundException.php
+++ b/src/Exception/PDODriverNotFoundException.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This file is part of the Phalcon Developer Tools.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Phalcon\DevTools\Exception;
+
+use PDOException;
+use Phalcon\Devtools\Script\Color;
+use PDO;
+
+class PDODriverNotFoundException extends PDOException
+{
+    protected $adapter = '';
+
+    public function __construct($message, $adapter = '')
+    {
+        parent::__construct($message);
+        $this->adapter = $adapter;
+    }
+
+    public function getAdapter()
+    {
+        return $this->adapter;
+    }
+
+    public function writeNicelyFormattedErrorOutput()
+    {
+        fwrite(STDERR, Color::error($this->getMessage()) . PHP_EOL);
+
+        if (!extension_loaded('PDO')) {
+            fwrite(STDERR, Color::error('PDO extension is not loaded') . PHP_EOL);
+        } else {
+            $loadedDrivers = PDO::getAvailableDrivers();
+            fwrite(STDERR, 'PDO Drivers loaded:' . PHP_EOL);
+            fwrite(STDERR, print_r($loadedDrivers, true). PHP_EOL);
+        }
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/phalcon-devtools/issues/1479

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:

If using a PDO driver such as Postgresql or Mysql, and it is not loaded when trying to go through the Phalcon adapter, PDO will error with the vague "could not find driver" which will leave developers on a quest to figure out what happened.
This PR will fix the vague issue for 4.0.x and it will instead show a much more detailed error.

Thanks
