### PR TITLE
Fix #1479 more verbose pdo driver missing errors for 4.1.x

### DIFF
--- a/phalcon
+++ b/phalcon
@@ -24,6 +24,7 @@ use Phalcon\DevTools\Commands\Builtin\Serve;
 use Phalcon\DevTools\Commands\Builtin\Webtools;
 use Phalcon\DevTools\Commands\CommandsListener;
 use Phalcon\DevTools\Commands\DotPhalconMissingException;
+use Phalcon\DevTools\Exception\PDODriverNotFoundException;
 use Phalcon\DevTools\Script;
 use Phalcon\DevTools\Script\Color;
 use Phalcon\DevTools\Version;
@@ -71,6 +72,11 @@ try {
     }
 } catch (PhalconException $e) {
     fwrite(STDERR, Color::error($e->getMessage()) . PHP_EOL);
+    exit(1);
+} catch (PDODriverNotFoundException $e) {
+    $e->writeNicelyFormattedErrorOutput();
+    fwrite(STDERR, 'Backtrace:'. PHP_EOL);
+    fwrite(STDERR, $e->getTraceAsString() . PHP_EOL);
     exit(1);
 } catch (Exception $e) {
     fwrite(STDERR, 'ERROR: ' . $e->getMessage() . PHP_EOL);

--- a/src/Exception/PDODriverNotFoundException.php
+++ b/src/Exception/PDODriverNotFoundException.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This file is part of the Phalcon Developer Tools.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Phalcon\DevTools\Exception;
+
+use PDOException;
+use Phalcon\Devtools\Script\Color;
+use PDO;
+
+class PDODriverNotFoundException extends PDOException
+{
+    protected $adapter = '';
+
+    public function __construct($message, $adapter = '')
+    {
+        parent::__construct($message);
+        $this->adapter = $adapter;
+    }
+
+    public function getAdapter()
+    {
+        return $this->adapter;
+    }
+
+    public function writeNicelyFormattedErrorOutput()
+    {
+        fwrite(STDERR, Color::error($this->getMessage()) . PHP_EOL);
+
+        if (!extension_loaded('PDO')) {
+            fwrite(STDERR, Color::error('PDO extension is not loaded') . PHP_EOL);
+        } else {
+            $loadedDrivers = PDO::getAvailableDrivers();
+            fwrite(STDERR, 'PDO Drivers loaded:' . PHP_EOL);
+            fwrite(STDERR, print_r($loadedDrivers, true). PHP_EOL);
+        }
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/phalcon-devtools/issues/1479

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:

If using a PDO driver such as Postgresql or Mysql, and it is not loaded when trying to go through the Phalcon adapter, PDO will error with the vague "could not find driver" which will leave developers on a quest to figure out what happened.
This PR will fix the vague issue for 4.1.x and it will instead show a much more detailed error.

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md