### PR TITLE
Fix #1508 devtools version showing phalcon version instead for 4.1.x

### DIFF
--- a/src/Version.php
+++ b/src/Version.php
@@ -25,7 +25,7 @@ class Version extends PhVersion
      * @return array
      */
     // phpcs:disable
-    protected static function _getVersion(): array
+    protected static function getVersion(): array
     {
         return [4, 1, 0, 0, 0];
     }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/phalcon-devtools/issues/1508

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:

4.1.x uses _getVersion() instead of getVersion() when extending Phacon\Version,
this results in devtools reporting back the wrong version of devtools to the user as though devtools and phalcon have the same version when they really have different versions.

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
