### PR TITLE
Fix missing return type for _getVersion()

### DIFF
--- a/scripts/Phalcon/Devtools/Version.php
+++ b/scripts/Phalcon/Devtools/Version.php
@@ -37,7 +37,7 @@ class Version extends PhVersion
      *
      * @return array
      */
-    protected static function _getVersion()
+    protected static function _getVersion(): array
     {
         return [3, 4, 14, 0, 0];
     }


### PR DESCRIPTION
We're still using 3.4.x on PHP 7.4

There's a type error caused by a missing return type that was added to Phalcon\Version.

```
Fatal error: Declaration of Phalcon\Devtools\Version::_getVersion() must be compatible with Phalcon\Version::_getVersion(): array in /usr/share/phalcon-devtools/scripts/Phalcon/Devtools/Version.php on line 40
```

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
