### PR TITLE
bugfix/invalid_config_call Fixed the way Config class was called

### DIFF
--- a/src/Builder/Component/AbstractComponent.php
+++ b/src/Builder/Component/AbstractComponent.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Phalcon\DevTools\Builder\Component;
 
-use Phalcon\Config;
+use Phalcon\Config\Config;
 use Phalcon\DevTools\Builder\Exception\BuilderException;
 use Phalcon\DevTools\Builder\Path;
 use Phalcon\DevTools\Script\Color;

--- a/src/Builder/Path.php
+++ b/src/Builder/Path.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Phalcon\DevTools\Builder;
 
-use Phalcon\Config;
+use Phalcon\Config\Config;
 use Phalcon\Config\Adapter\Ini as ConfigIni;
 use Phalcon\DevTools\Builder\Exception\BuilderException;
 use RecursiveDirectoryIterator;

--- a/src/Builder/Project/ProjectAware.php
+++ b/src/Builder/Project/ProjectAware.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Phalcon\DevTools\Builder\Project;
 
-use Phalcon\Config;
+use Phalcon\Config\Config;
 
 /**
  * @property Config $options

--- a/src/Builder/Project/ProjectBuilder.php
+++ b/src/Builder/Project/ProjectBuilder.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Phalcon\DevTools\Builder\Project;
 
-use Phalcon\Config;
+use Phalcon\Config\Config;
 
 /**
  * Abstract Builder to create application skeletons

--- a/src/Commands/Builtin/AllModels.php
+++ b/src/Commands/Builtin/AllModels.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Phalcon\DevTools\Commands\Builtin;
 
-use Phalcon\Config;
+use Phalcon\Config\Config;
 use Phalcon\Config\Adapter\Ini as ConfigIni;
 use Phalcon\DevTools\Builder\Component\AllModels as AllModelsBuilder;
 use Phalcon\DevTools\Builder\Exception\BuilderException;

--- a/src/Commands/Builtin/Migration.php
+++ b/src/Commands/Builtin/Migration.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Phalcon\DevTools\Commands\Builtin;
 
-use Phalcon\Config;
+use Phalcon\Config\Config;
 use Phalcon\DevTools\Commands\Command;
 use Phalcon\DevTools\Commands\CommandsException;
 use Phalcon\DevTools\Script\Color;

--- a/src/Commands/Builtin/Model.php
+++ b/src/Commands/Builtin/Model.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Phalcon\DevTools\Commands\Builtin;
 
-use Phalcon\Config;
+use Phalcon\Config\Config;
 use Phalcon\Config\Adapter\Ini as ConfigIni;
 use Phalcon\DevTools\Builder\Component\Model as ModelBuilder;
 use Phalcon\DevTools\Builder\Exception\BuilderException;

--- a/src/Commands/Builtin/Scaffold.php
+++ b/src/Commands/Builtin/Scaffold.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Phalcon\DevTools\Commands\Builtin;
 
-use Phalcon\Config;
+use Phalcon\Config\Config;
 use Phalcon\DevTools\Builder\Component\Scaffold as ScaffoldBuilder;
 use Phalcon\DevTools\Builder\Exception\BuilderException;
 use Phalcon\DevTools\Commands\Command;

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Phalcon\DevTools\Commands;
 
-use Phalcon\Config;
+use Phalcon\Config\Config;
 use Phalcon\Config\Adapter\Ini as IniConfig;
 use Phalcon\Config\Adapter\Json as JsonConfig;
 use Phalcon\Config\Adapter\Yaml as YamlConfig;

--- a/src/Mvc/Controller/Base.php
+++ b/src/Mvc/Controller/Base.php
@@ -15,7 +15,7 @@ namespace Phalcon\DevTools\Mvc\Controller;
 use Phalcon\Assets\Filters\Cssmin;
 use Phalcon\Assets\Filters\Jsmin;
 use Phalcon\Assets\Manager;
-use Phalcon\Config;
+use Phalcon\Config\Config;
 use Phalcon\DevTools\Resources\AssetsResource;
 use Phalcon\DevTools\Utils\DbUtils;
 use Phalcon\DevTools\Utils\FsUtils;

--- a/src/Providers/ConfigProvider.php
+++ b/src/Providers/ConfigProvider.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Phalcon\DevTools\Providers;
 
-use Phalcon\Config;
+use Phalcon\Config\Config;
 use Phalcon\DevTools\Scanners\Config as ConfigScanner;
 use Phalcon\Di\DiInterface;
 use Phalcon\Di\ServiceProviderInterface;

--- a/src/Providers/RegistryProvider.php
+++ b/src/Providers/RegistryProvider.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Phalcon\DevTools\Providers;
 
-use Phalcon\Config;
+use Phalcon\Config\Config;
 use Phalcon\DevTools\Bootstrap;
 use Phalcon\DevTools\Utils\FsUtils;
 use Phalcon\Di\DiInterface;

--- a/src/Providers/UrlProvider.php
+++ b/src/Providers/UrlProvider.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Phalcon\DevTools\Providers;
 
-use Phalcon\Config;
+use Phalcon\Config\Config;
 use Phalcon\Di\DiInterface;
 use Phalcon\Di\ServiceProviderInterface;
 use Phalcon\Url as UrlResolver;

--- a/src/Providers/VoltProvider.php
+++ b/src/Providers/VoltProvider.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Phalcon\DevTools\Providers;
 
-use Phalcon\Config;
+use Phalcon\Config\Config;
 use Phalcon\DevTools\Mvc\View\Engine\Volt\Extension\Php as PhpExt;
 use Phalcon\Di\DiInterface;
 use Phalcon\Di\ServiceProviderInterface;

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 namespace Phalcon\DevTools;
 
 use InvalidArgumentException;
-use Phalcon\Config;
+use Phalcon\Config\Config;
 
 class Utils
 {

--- a/src/Utils/DbUtils.php
+++ b/src/Utils/DbUtils.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Phalcon\DevTools\Utils;
 
-use Phalcon\Config;
+use Phalcon\Config\Config;
 use Phalcon\Di\Injectable;
 
 /**

--- a/tests/_data/console/app/mysql/config.php
+++ b/tests/_data/console/app/mysql/config.php
@@ -1,6 +1,6 @@
 <?php
 
-use Phalcon\Config;
+use Phalcon\Config\Config;
 use Phalcon\Logger;
 
 return new Config([

--- a/tests/_data/console/app/postgresql/config.php
+++ b/tests/_data/console/app/postgresql/config.php
@@ -1,6 +1,6 @@
 <?php
 
-use Phalcon\Config;
+use Phalcon\Config\Config;
 use Phalcon\Logger;
 
 return new Config([


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: https://github.com/phalcon/phalcon-devtools/issues/1526

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines][:contrib:]
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

The PR consists of the fix where the Dev tool was not compatible with Phalcon version 5.2.3

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
