### PR TITLE
FIX: with latest phalcon 5 Phalcon\Config is moved to Phalcon\Config\Config

### DIFF
--- a/templates/module/variables.json
+++ b/templates/module/variables.json
@@ -2,7 +2,7 @@
     "config-type": {
         "php": {
             "configLoader": "new Config(include __DIR__ . '/config/config.php')",
-            "iniConfigImport": "use Phalcon\\Config;",
+            "iniConfigImport": "use Phalcon\\Config\\Config;",
             "configName": "__DIR__ . '/config/config.php'",
             "useConfig": ""
         },
@@ -10,19 +10,19 @@
             "configLoader": "new Ini(__DIR__ . '/config/config.ini')",
             "iniConfigImport": "use Phalcon\\Config\\Adapter\\Ini;",
             "configName": "__DIR__ . '/config/config.ini'",
-            "useConfig": "use Phalcon\\Config;"
+            "useConfig": "use Phalcon\\Config\\Config;"
         },
         "yaml": {
             "configLoader": "new Yaml(__DIR__ . '/config/config.yaml', array('!local' => function($value) { return __DIR__ . $value; }))",
             "iniConfigImport": "use Phalcon\\Config\\Adapter\\Yaml;",
             "configName": "__DIR__ . '/config/config.yaml'",
-            "useConfig": "use Phalcon\\Config;"
+            "useConfig": "use Phalcon\\Config\\Config;"
         },
         "json": {
             "configLoader": "new Json(__DIR__ . '/config/config.json')",
             "iniConfigImport": "use Phalcon\\Config\\Adapter\\Json;",
             "configName": "__DIR__ . '/config/config.json'",
-            "useConfig": "use Phalcon\\Config;"
+            "useConfig": "use Phalcon\\Config\\Config;"
         }
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix

**In raising this pull request, I confirm the following (please check boxes):**

- [ x ] I have read and understood the [Contributing Guidelines][:contrib:]
- [ x ] I have checked that another pull request for this purpose does not exist
- [ x ] I wrote some tests for this PR

**Small description of change**:

It is a simple fix: we just update Phalcon\Config to Phalcon\Config\Config in templates.

Thanks
